### PR TITLE
[feature/54 roulette map] - 카카오맵 외부 링크 연결

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,15 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-
 import type { FormEvent } from 'react';
-
 import { MapPin, Shuffle, Table2 } from 'lucide-react';
-
 import Carousel, { pendingData } from '@/shared/components/Carousel';
 import Clock from '@/shared/components/Clock/Clock';
-import TopTabs from '@/shared/components/TopTabs';
+import TopTabs, { TopTabItem } from '@/shared/components/TopTabs';
 import WeatherMood from '@/domain/WeatherMood/WeatherMood';
 import Ladder from '@/domain/Ladder/Ladder';
 import Roulette from '@/domain/Roulette/Roulette';
 import KakaoMap from '@/shared/components/KakaoMap';
-
-import type { TopTabItem } from '@/shared/components/TopTabs';
-
 import styles from './page.module.scss';
 
 const TAB_LIST = [
@@ -32,6 +26,7 @@ export default function HomePage() {
   const [isSpinning, setIsSpinning] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searchValue, setSearchValue] = useState('맛집');
+  const [rouletteResult, setRouletteResult] = useState<string | null>(null);
 
   const handleSearch = useCallback(
     (e: FormEvent) => {
@@ -56,7 +51,11 @@ export default function HomePage() {
         <Roulette
           isSpinning={isSpinning}
           onSpinStart={() => setIsSpinning(true)}
-          onSpinResult={() => setIsSpinning(false)}
+          onSpinResult={result => {
+            setIsSpinning(false);
+            setRouletteResult(result);
+          }}
+          result={rouletteResult}
         />
       );
     }
@@ -85,7 +84,7 @@ export default function HomePage() {
           </form>
 
           <div className={styles['container__left__main__menu-tab-map__map']}>
-            <KakaoMap keyword={searchKeyword} />
+            <KakaoMap keyword={rouletteResult || searchKeyword} />
           </div>
         </div>
       );
@@ -112,7 +111,9 @@ export default function HomePage() {
           </section>
 
           <section className={styles['container__left__main__option']}>찬성 반대</section>
-          <section className={styles['container__left__main__map']} />
+          <section className={styles['container__left__main__map']}>
+            <KakaoMap keyword={rouletteResult || searchKeyword} list={false} />
+          </section>
         </div>
       </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,7 +84,7 @@ export default function HomePage() {
           </form>
 
           <div className={styles['container__left__main__menu-tab-map__map']}>
-            <KakaoMap keyword={rouletteResult || searchKeyword} />
+            <KakaoMap keyword={searchKeyword} />
           </div>
         </div>
       );
@@ -111,9 +111,11 @@ export default function HomePage() {
           </section>
 
           <section className={styles['container__left__main__option']}>찬성 반대</section>
-          <section className={styles['container__left__main__map']}>
-            <KakaoMap keyword={rouletteResult || searchKeyword} list={false} />
-          </section>
+          {rouletteResult && (
+            <section className={styles['container__left__main__map']}>
+              <KakaoMap keyword={rouletteResult || searchKeyword} list={false} />
+            </section>
+          )}
         </div>
       </div>
 

--- a/src/domain/Roulette/Roulette.tsx
+++ b/src/domain/Roulette/Roulette.tsx
@@ -52,7 +52,7 @@ export const Roulette = memo(function Roulette({
     if (!result) return;
     setModalOpen(true);
   }, [result]);
-  console.log(result);
+
   return (
     <div className={styles['roulette']}>
       <p className={styles['roulette__today']}>

--- a/src/domain/Roulette/Roulette.tsx
+++ b/src/domain/Roulette/Roulette.tsx
@@ -19,9 +19,9 @@ export const Roulette = memo(function Roulette({
   isSpinning,
   onSpinStart,
   onSpinResult,
+  result,
 }: RouletteControllerProps) {
   const [menus, setMenus] = useState<MenuItem[]>([]);
-  const [result, setResult] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
 
   // 섞기 가능 여부
@@ -36,7 +36,6 @@ export const Roulette = memo(function Roulette({
   // 룰렛 결과 처리
   const handleResult = useCallback(
     (item: MenuItem) => {
-      setResult(item.name);
       setModalOpen(true);
       onSpinResult(item.name);
     },
@@ -53,7 +52,7 @@ export const Roulette = memo(function Roulette({
     if (!result) return;
     setModalOpen(true);
   }, [result]);
-
+  console.log(result);
   return (
     <div className={styles['roulette']}>
       <p className={styles['roulette__today']}>

--- a/src/domain/Roulette/components/RouletteModal/RouletteModal.tsx
+++ b/src/domain/Roulette/components/RouletteModal/RouletteModal.tsx
@@ -53,7 +53,13 @@ export default function RouletteModal({ menu, onClose }: RouletteModalProps) {
             공유하기
           </Button>
 
-          <Button variant="neutral" size="md">
+          <Button
+            variant="neutral"
+            size="md"
+            onClick={() =>
+              window.open(`https://map.kakao.com/?q=${encodeURIComponent(menu)}`, '_blank')
+            }
+          >
             지도 보기
           </Button>
 

--- a/src/domain/Roulette/type.ts
+++ b/src/domain/Roulette/type.ts
@@ -1,6 +1,6 @@
-// 룰렛 동작을 제어하는 상위 컨테이너의 Props
 export interface RouletteControllerProps {
   isSpinning: boolean;
   onSpinStart: () => void;
   onSpinResult: (item: string) => void;
+  result: string | null;
 }

--- a/src/shared/components/KakaoMap/KakaoMap.module.scss
+++ b/src/shared/components/KakaoMap/KakaoMap.module.scss
@@ -12,10 +12,10 @@
 }
 
 .map {
-  width: 70%;
+  flex: 1 1 0;
 
   &__place-list {
-    flex: 1 1 0;
+    width: 30%;
     height: 100%;
     overflow-y: auto;
     background: f.color(white);

--- a/src/shared/components/KakaoMap/KakaoMap.tsx
+++ b/src/shared/components/KakaoMap/KakaoMap.tsx
@@ -66,9 +66,11 @@ function KakaoMap({ keyword, list = true }: KakaoMapProps) {
   const createInfoWindowContent = useCallback((place: Kakao.PlaceItem) => {
     return `
       <div style="padding: 12px; min-width: 200px;">
-        <h4 style="margin: 0 0 8px 0; font-size: 14px; font-weight: bold; color: #333;">
-             ${escapeHtml(place.place_name)}
-        </h4>
+       <h4 style="margin: 0 0 8px 0; font-size: 14px; font-weight: bold; color: #333;">
+        <a href="${escapeHtml(place.place_url)}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none;">
+          ${escapeHtml(place.place_name)}
+        </a>
+      </h4>
         <p style="margin: 4px 0; font-size: 12px; color: #666;">
           ${escapeHtml(place.road_address_name || place.address_name)}
         </p>

--- a/src/shared/components/KakaoMap/KakaoMap.tsx
+++ b/src/shared/components/KakaoMap/KakaoMap.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef, memo } from 'react';
 import styles from './KakaoMap.module.scss';
 import { KakaoMapProps } from './types';
 
@@ -10,7 +10,7 @@ const SEARCH_RADIUS = 3000;
 const DEBOUNCE_DELAY = 300;
 const DEFAULT_COORDS = { lat: 37.5665, lng: 126.978 }; // 서울시청
 
-export default function KakaoMap({ keyword }: KakaoMapProps) {
+function KakaoMap({ keyword, list = true }: KakaoMapProps) {
   const [places, setPlaces] = useState<Kakao.PlacesSearchResult>([]);
   const [mapReady, setMapReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -346,33 +346,38 @@ export default function KakaoMap({ keyword }: KakaoMapProps) {
       {error && <div className={styles['error-message']}>{error}</div>}
       <div ref={mapContainerRef} className={styles['map']} />
 
-      <div className={styles['map__place-list']}>
-        {places.length > 0 ? (
-          <ul className={styles['map__place-list__list']}>
-            {places.map(place => (
-              <li
-                key={place.id}
-                className={styles['map__place-list__list__item']}
-                onClick={() => handlePlaceClick(place)}
-              >
-                <span className={styles['map__place-list__list__item__name']}>
-                  {place.place_name}
-                </span>
-                <div className={styles['map__place-list__list__item__address']}>
-                  {place.road_address_name || place.address_name}
-                </div>
-                {place.phone && (
-                  <div className={styles['map__place-list__list__item__phone']}>{place.phone}</div>
-                )}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div className={styles['map__place-list__search-prompt']}>
-            {keyword ? '검색 결과가 없습니다.' : '검색어를 입력하세요.'}
-          </div>
-        )}
-      </div>
+      {list && (
+        <div className={styles['map__place-list']}>
+          {places.length > 0 ? (
+            <ul className={styles['map__place-list__list']}>
+              {places.map(place => (
+                <li
+                  key={place.id}
+                  className={styles['map__place-list__list__item']}
+                  onClick={() => handlePlaceClick(place)}
+                >
+                  <span className={styles['map__place-list__list__item__name']}>
+                    {place.place_name}
+                  </span>
+                  <div className={styles['map__place-list__list__item__address']}>
+                    {place.road_address_name || place.address_name}
+                  </div>
+                  {place.phone && (
+                    <div className={styles['map__place-list__list__item__phone']}>
+                      {place.phone}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className={styles['map__place-list__search-prompt']}>
+              {keyword ? '검색 결과가 없습니다.' : '검색어를 입력하세요.'}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
+export default memo(KakaoMap);

--- a/src/shared/components/KakaoMap/types.ts
+++ b/src/shared/components/KakaoMap/types.ts
@@ -1,7 +1,7 @@
 export interface KakaoMapProps {
   keyword?: string;
 
-  /** list
+  /**
    * @default true
    */
   list?: boolean;

--- a/src/shared/components/KakaoMap/types.ts
+++ b/src/shared/components/KakaoMap/types.ts
@@ -1,3 +1,8 @@
 export interface KakaoMapProps {
   keyword?: string;
+
+  /** list
+   * @default true
+   */
+  list?: boolean;
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -16,6 +16,7 @@ declare global {
       phone: string;
       x: string;
       y: string;
+      place_url: string;
     }
 
     type PlacesSearchResult = PlaceItem[];


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

1. 기존 roulette에서 결과값을 보내줬는데 카카오맵도 결과를 받아야만 해서 최상위 page에서 룰렛 결과를 관리합니다. 
2. 카카오맵 타입이 변동되었습니다 list를 받고 기본적으로 true입니다

## 📸 스크린샷

<img width="1184" height="816" alt="스크린샷 2025-12-22 오후 7 24 05" src="https://github.com/user-attachments/assets/913536e0-6404-4cd2-bd19-756435c2867e" />

## 🛠️ 테스트 방법


1. 룰렛을 돌린 후에 콘솔에 찍힌 것과 동일한 값으로 렌더링 됩니다.
3. toptabs에 있는 지도와 결과를 보여주는 맵은 서로 외부 링크와 연결되어있습니다 (가게이름 클릭시 이동)
4.

## 🚧 관련 이슈

1. 결과가 나오면 그 후에 맵이 렌더링 됩니다. 
2. 기존 roulette에서 결과값을 보내줬는데 카카오맵도 결과를 받아야만 해서 최상위 page에서 룰렛 결과를 관리합니다. 

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
