### PR TITLE
[refactor/login-fix] - Toastify 적용 및 로그인 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 WEATHER_API_KEY=
 NEXT_PUBLIC_KAKAO_MAP_KEY=
-BASE_URL=
 
-# fetcher가 실제로 보는 값으로 백엔드 render 주소 사용
-NEXT_PUBLIC_SOCKET_URL= 
+# API base url
 NEXT_PUBLIC_API_BASE_URL=
+
+# frontend base url
+NEXT_PUBLIC_BASE_URL=
+
+# socket server url
+NEXT_PUBLIC_SOCKET_URL=

--- a/src/app/ClientWarmup.tsx
+++ b/src/app/ClientWarmup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { toast } from 'react-toastify';
 import { useAuthStore } from '@/domain/Auth/store/auth.store';
 import { authService } from '@/app/services/backend/auth.api';
 
@@ -13,6 +14,9 @@ export default function ClientWarmUp() {
     mounted.current = true;
 
     const initializeAuth = async () => {
+      // SSR 환경 보호
+      if (typeof window === 'undefined') return;
+
       try {
         const token = localStorage.getItem('accessToken');
 
@@ -30,6 +34,7 @@ export default function ClientWarmUp() {
         }
       } catch (error) {
         console.error('[ClientWarmUp] 세션 만료 또는 오류:', error);
+        toast.info('세션이 만료되었습니다. 다시 로그인해주세요.');
         authService.postLogout(); // 로컬스토리지 청소
         clearUser(); // 스토어 초기화
       } finally {

--- a/src/app/ClientWarmup.tsx
+++ b/src/app/ClientWarmup.tsx
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import { useAuthStore } from '@/domain/Auth/store/auth.store';
 import { authService } from '@/app/services/backend/auth.api';
 
-export default function ClientWarmUp() {
+export default function ClientWarmup() {
   const { setUser, clearUser, finishAuthCheck } = useAuthStore();
   const mounted = useRef(false);
 

--- a/src/app/ClientWarmup.tsx
+++ b/src/app/ClientWarmup.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useAuthStore } from '@/domain/Auth/store/auth.store';
+import { authService } from '@/app/services/backend/auth.api';
+
+export default function ClientWarmUp() {
+  const { setUser, clearUser, finishAuthCheck } = useAuthStore();
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    if (mounted.current) return;
+    mounted.current = true;
+
+    const initializeAuth = async () => {
+      try {
+        const token = localStorage.getItem('accessToken');
+
+        if (!token) {
+          finishAuthCheck(); // 토큰 없으면 비로그인 상태로 확정
+          return;
+        }
+
+        const userData = await authService.getMe();
+
+        if (userData) {
+          setUser(userData);
+        } else {
+          throw new Error('User data is empty');
+        }
+      } catch (error) {
+        console.error('[ClientWarmUp] 세션 만료 또는 오류:', error);
+        authService.postLogout(); // 로컬스토리지 청소
+        clearUser(); // 스토어 초기화
+      } finally {
+        finishAuthCheck();
+      }
+    };
+
+    // 기존 백엔드 Health Check
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+    if (baseUrl) {
+      fetch(`${baseUrl}/health`, { method: 'GET', cache: 'no-store' }).catch(() => {});
+    }
+
+    initializeAuth();
+  }, [setUser, clearUser, finishAuthCheck]);
+
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,9 @@
 import type { Metadata } from 'next';
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
-
 import Header from '@/shared/components/layout/Header';
 import Main from '@/shared/components/layout/Main';
 import TanstackProvider from '@/shared/context/TanstackProvider';
-import ClientWarmUp from './ClientWarmup';
+import ClientWarmUp from './ClientWarmUp';
+import GlobalToast from '@/shared/components/Toast/GlobalToast';
 
 import '@/styles/main.scss';
 
@@ -33,18 +31,7 @@ export default function RootLayout({ children }: LayoutProps) {
           <Header />
           <Main>{children}</Main>
         </TanstackProvider>
-        <ToastContainer
-          position="top-center"
-          autoClose={3000}
-          hideProgressBar={false}
-          newestOnTop={false}
-          closeOnClick
-          rtl={false}
-          pauseOnFocusLoss
-          draggable
-          pauseOnHover
-          theme="light"
-        />
+        <GlobalToast />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
 import Header from '@/shared/components/layout/Header';
 import Main from '@/shared/components/layout/Main';
 import TanstackProvider from '@/shared/context/TanstackProvider';
+import ClientWarmUp from './ClientWarmup';
+
 import '@/styles/main.scss';
 
 export const metadata: Metadata = {
@@ -23,10 +28,23 @@ export default function RootLayout({ children }: LayoutProps) {
       ) : null}
 
       <body>
+        <ClientWarmUp />
         <TanstackProvider>
           <Header />
           <Main>{children}</Main>
         </TanstackProvider>
+        <ToastContainer
+          position="top-center"
+          autoClose={3000}
+          hideProgressBar={false}
+          newestOnTop={false}
+          closeOnClick
+          rtl={false}
+          pauseOnFocusLoss
+          draggable
+          pauseOnHover
+          theme="light"
+        />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Header from '@/shared/components/layout/Header';
 import Main from '@/shared/components/layout/Main';
 import TanstackProvider from '@/shared/context/TanstackProvider';
-import ClientWarmUp from './ClientWarmUp';
+import ClientWarmup from './ClientWarmup';
 import GlobalToast from '@/shared/components/Toast/GlobalToast';
 
 import '@/styles/main.scss';
@@ -26,7 +26,7 @@ export default function RootLayout({ children }: LayoutProps) {
       ) : null}
 
       <body>
-        <ClientWarmUp />
+        <ClientWarmup />
         <TanstackProvider>
           <Header />
           <Main>{children}</Main>

--- a/src/domain/Auth/LoginModal/LoginModal.tsx
+++ b/src/domain/Auth/LoginModal/LoginModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react';
 import Image from 'next/image';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 import Button from '@/shared/components/Button';
 import BaseInput from '@/shared/components/Input/BaseInput';
@@ -53,10 +54,11 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
         nickname: me.nickname,
         profileImage: me.profileImage,
       });
+
       onClose();
     },
     onError: (error: unknown) => {
-      alert(getLoginErrorMessage(error));
+      toast.error(getLoginErrorMessage(error));
     },
   });
 
@@ -64,11 +66,16 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
     if (!emailRef.current?.value || !password) {
-      alert('이메일과 비밀번호를 입력해주세요');
+      toast.warn('이메일과 비밀번호를 입력해주세요.');
       return;
     }
-    loginMutation.mutate({ email: emailRef.current.value, password });
+
+    loginMutation.mutate({
+      email: emailRef.current.value,
+      password,
+    });
   };
 
   return (
@@ -95,7 +102,6 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
               <span>간편 로그인하기</span>
               <button
                 type="button"
-                role="button"
                 className={styles['auth__social__oauth--google']}
                 aria-label="Google로 로그인"
               >

--- a/src/domain/Auth/LoginModal/LoginModal.tsx
+++ b/src/domain/Auth/LoginModal/LoginModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from 'react';
 import Image from 'next/image';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 
 import Button from '@/shared/components/Button';
@@ -41,20 +41,11 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
   const [password, setPassword] = useState('');
 
   const setUser = useAuthStore(state => state.setUser);
-  const queryClient = useQueryClient();
 
   const loginMutation = useMutation({
     mutationFn: (data: Auth.LoginReq) => authService.postLogin(data),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['me'] });
-      const me = await authService.getMe();
-
-      setUser({
-        email: me.email,
-        nickname: me.nickname,
-        profileImage: me.profileImage,
-      });
-
+    onSuccess: res => {
+      setUser(res.user);
       onClose();
     },
     onError: (error: unknown) => {

--- a/src/domain/Auth/SignupModal/SignupModal.tsx
+++ b/src/domain/Auth/SignupModal/SignupModal.tsx
@@ -24,51 +24,44 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
 
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
-  const [loading, setLoading] = useState(false);
 
   const clearUser = useAuthStore(state => state.clearUser);
 
   const signupMutation = useMutation({
     mutationFn: (data: Auth.RegisterReq) => authService.postSignup(data),
     onSuccess: () => {
-      // 이전 로그인 상태 제거
       clearUser();
-      toast.success('회원가입이 완료되었습니다! 로그인해주세요.', {
-        position: 'top-center',
-        autoClose: 3000,
-      });
+      toast.success('회원가입이 완료되었습니다! 로그인해주세요.');
       onLoginOpen();
     },
     onError: (error: unknown) => {
-      // 에러 토스트
       if (error instanceof Error) {
-        toast.error(error.message, { position: 'top-center' });
+        toast.error(error.message);
       } else {
-        toast.error('회원가입에 실패했습니다. 다시 시도해주세요.', { position: 'top-center' });
+        toast.error('회원가입에 실패했습니다. 다시 시도해주세요.');
       }
-    },
-    onSettled: () => {
-      setLoading(false);
     },
   });
 
+  const isLoading = signupMutation.isPending;
+
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
     if (!emailRef.current?.value || !nicknameRef.current?.value || !password || !passwordConfirm) {
-      toast.warn('모든 항목을 입력해주세요.', { position: 'top-center' });
-      return;
-    }
-    if (password !== passwordConfirm) {
-      toast.warn('비밀번호가 일치하지 않습니다.', { position: 'top-center' });
+      toast.warn('모든 항목을 입력해주세요.');
       return;
     }
 
-    setLoading(true);
+    if (password !== passwordConfirm) {
+      toast.warn('비밀번호가 일치하지 않습니다.');
+      return;
+    }
 
     signupMutation.mutate({
       email: emailRef.current.value,
-      password: password,
-      passwordConfirm: passwordConfirm,
+      password,
+      passwordConfirm,
       nickname: nicknameRef.current.value,
     });
   };
@@ -83,7 +76,7 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               ref={nicknameRef}
               type="text"
               placeholder="닉네임을 입력하세요"
-              disabled={loading}
+              disabled={isLoading}
             />
           </div>
 
@@ -93,7 +86,7 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               ref={emailRef}
               type="email"
               placeholder="이메일을 입력하세요"
-              disabled={loading}
+              disabled={isLoading}
             />
           </div>
 
@@ -103,7 +96,7 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               value={password}
               placeholder="비밀번호를 입력하세요"
               onChange={e => setPassword(e.target.value)}
-              disabled={loading}
+              disabled={isLoading}
             />
           </div>
 
@@ -113,7 +106,7 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               value={passwordConfirm}
               placeholder="비밀번호를 다시 입력하세요"
               onChange={e => setPasswordConfirm(e.target.value)}
-              disabled={loading}
+              disabled={isLoading}
             />
           </div>
         </div>
@@ -135,7 +128,7 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               type="button"
               className={styles['auth__actions__signup']}
               onClick={onLoginOpen}
-              disabled={loading}
+              disabled={isLoading}
             >
               로그인하기
             </button>
@@ -148,7 +141,7 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               mode="outline"
               className={styles['auth__actions__buttons__button']}
               onClick={onClose}
-              disabled={loading}
+              disabled={isLoading}
             >
               취소
             </Button>
@@ -157,9 +150,9 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
               type="submit"
               variant="blue"
               className={styles['auth__actions__buttons__button']}
-              disabled={loading}
+              disabled={isLoading}
             >
-              {loading ? '처리 중...' : '회원가입'}
+              {isLoading ? '처리 중...' : '회원가입'}
             </Button>
           </div>
         </div>

--- a/src/domain/Auth/SignupModal/SignupModal.tsx
+++ b/src/domain/Auth/SignupModal/SignupModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react';
 import Image from 'next/image';
 import { useMutation } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 import Button from '@/shared/components/Button';
 import BaseInput from '@/shared/components/Input/BaseInput';
@@ -25,7 +26,6 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [loading, setLoading] = useState(false);
 
-  // 전역 auth 상태 초기화용
   const clearUser = useAuthStore(state => state.clearUser);
 
   const signupMutation = useMutation({
@@ -33,14 +33,18 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
     onSuccess: () => {
       // 이전 로그인 상태 제거
       clearUser();
-      alert('회원가입이 완료되었습니다');
+      toast.success('회원가입이 완료되었습니다! 로그인해주세요.', {
+        position: 'top-center',
+        autoClose: 3000,
+      });
       onLoginOpen();
     },
     onError: (error: unknown) => {
+      // 에러 토스트
       if (error instanceof Error) {
-        alert(error.message);
+        toast.error(error.message, { position: 'top-center' });
       } else {
-        alert('회원가입에 실패했습니다');
+        toast.error('회원가입에 실패했습니다. 다시 시도해주세요.', { position: 'top-center' });
       }
     },
     onSettled: () => {
@@ -48,33 +52,25 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
     },
   });
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!emailRef.current?.value || !nicknameRef.current?.value || !password || !passwordConfirm) {
-      alert('모든 항목을 입력해주세요');
+      toast.warn('모든 항목을 입력해주세요.', { position: 'top-center' });
       return;
     }
     if (password !== passwordConfirm) {
-      alert('비밀번호가 일치하지 않습니다');
+      toast.warn('비밀번호가 일치하지 않습니다.', { position: 'top-center' });
       return;
     }
-    try {
-      setLoading(true);
-      await signupMutation.mutateAsync({
-        email: emailRef.current.value,
-        password: password,
-        passwordConfirm: passwordConfirm,
-        nickname: nicknameRef.current.value,
-      });
-    } catch (err) {
-      if (err instanceof Error) {
-        alert(err.message);
-      } else {
-        alert('회원가입에 실패했습니다');
-      }
-    } finally {
-      setLoading(false);
-    }
+
+    setLoading(true);
+
+    signupMutation.mutate({
+      email: emailRef.current.value,
+      password: password,
+      passwordConfirm: passwordConfirm,
+      nickname: nicknameRef.current.value,
+    });
   };
 
   return (

--- a/src/domain/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
+++ b/src/domain/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 import BaseInput from '@/shared/components/Input/BaseInput/BaseInput';
 import PasswordInput from '@/shared/components/Input/PasswordInput/PasswordInput';
@@ -13,7 +14,7 @@ import { useAuthStore } from '@/domain/Auth/store/auth.store';
 import styles from './EditProfileForm.module.scss';
 
 interface EditProfileFormProps {
-  initialNickname: string; // 초기 닉네임
+  initialNickname: string;
   onSubmitSuccess: () => void;
   onCancel: () => void;
 }
@@ -26,7 +27,6 @@ interface EditProfileFormState {
 
 const MIN_NICKNAME_LENGTH = 2;
 
-// 개인 정보 수정 폼
 export default function EditProfileForm({
   initialNickname,
   onSubmitSuccess,
@@ -57,10 +57,19 @@ export default function EditProfileForm({
     mutationFn: (data: Auth.UpdateMeReq) => authService.updateMe(data),
     onSuccess: updatedUser => {
       setUser(updatedUser);
+
+      toast.success('회원 정보가 수정되었습니다.', {
+        position: 'top-center',
+        autoClose: 2000,
+      });
+
       onSubmitSuccess();
     },
-    onError: () => {
-      alert('정보 수정에 실패했습니다');
+    onError: error => {
+      console.error(error);
+      toast.error('정보 수정에 실패했습니다. 다시 시도해주세요.', {
+        position: 'top-center',
+      });
     },
   });
 
@@ -70,26 +79,26 @@ export default function EditProfileForm({
     const { newPassword, confirmPassword } = formState;
 
     if (!isNicknameChanged && !isPasswordChanged) {
-      alert('변경된 정보가 없습니다');
+      toast.info('변경된 정보가 없습니다.', { position: 'top-center' });
       return;
     }
 
     if (isNicknameChanged && trimmedNickname.length < MIN_NICKNAME_LENGTH) {
-      alert('닉네임은 2자 이상 입력해주세요');
+      toast.warn('닉네임은 2자 이상 입력해주세요.', { position: 'top-center' });
       return;
     }
 
-    if (isPasswordChanged && newPassword !== confirmPassword) {
-      alert('비밀번호가 일치하지 않습니다');
-      return;
+    if (isPasswordChanged) {
+      if (newPassword !== confirmPassword) {
+        toast.warn('비밀번호가 일치하지 않습니다.', { position: 'top-center' });
+        return;
+      }
+      if (newPassword.length < 8) {
+        toast.warn('비밀번호는 8자 이상이어야 합니다.', { position: 'top-center' });
+        return;
+      }
     }
 
-    if (isPasswordChanged && newPassword.length < 8) {
-      alert('비밀번호는 8자 이상이어야 합니다');
-      return;
-    }
-
-    // payload 없이 바로 전달
     updateMeMutation.mutate({
       ...(isNicknameChanged && { nickname: trimmedNickname }),
       ...(isPasswordChanged && { password: newPassword }),

--- a/src/domain/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
+++ b/src/domain/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
@@ -58,19 +58,12 @@ export default function EditProfileForm({
     mutationFn: (data: Auth.UpdateMeReq) => authService.updateMe(data),
     onSuccess: updatedUser => {
       setUser(updatedUser);
-
-      toast.success('회원 정보가 수정되었습니다.', {
-        position: 'top-center',
-        autoClose: 2000,
-      });
-
+      toast.success('회원 정보가 수정되었습니다.');
       onSubmitSuccess();
     },
     onError: error => {
       console.error(error);
-      toast.error('정보 수정에 실패했습니다. 다시 시도해주세요.', {
-        position: 'top-center',
-      });
+      toast.error('정보 수정에 실패했습니다. 다시 시도해주세요.');
     },
   });
 
@@ -80,31 +73,33 @@ export default function EditProfileForm({
     const { newPassword, confirmPassword } = formState;
 
     if (!isNicknameChanged && !isPasswordChanged) {
-      toast.info('변경된 정보가 없습니다.', { position: 'top-center' });
+      toast.info('변경된 정보가 없습니다.');
       return;
     }
 
     if (isNicknameChanged && trimmedNickname.length < MIN_NICKNAME_LENGTH) {
-      toast.warn('닉네임은 2자 이상 입력해주세요.', { position: 'top-center' });
+      toast.warn('닉네임은 2자 이상 입력해주세요.');
       return;
     }
 
     if (isPasswordChanged) {
       if (!newPassword) {
-        toast.warn('새 비밀번호를 입력해주세요.', { position: 'top-center' });
+        toast.warn('새 비밀번호를 입력해주세요.');
         return;
       }
+
       if (!confirmPassword) {
-        toast.warn('비밀번호 확인을 입력해주세요.', { position: 'top-center' });
+        toast.warn('비밀번호 확인을 입력해주세요.');
         return;
       }
 
       if (newPassword !== confirmPassword) {
-        toast.warn('비밀번호가 일치하지 않습니다.', { position: 'top-center' });
+        toast.warn('비밀번호가 일치하지 않습니다.');
         return;
       }
+
       if (newPassword.length < 8) {
-        toast.warn('비밀번호는 8자 이상이어야 합니다.', { position: 'top-center' });
+        toast.warn('비밀번호는 8자 이상이어야 합니다.');
         return;
       }
     }

--- a/src/domain/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
+++ b/src/domain/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
@@ -51,7 +51,8 @@ export default function EditProfileForm({
 
   const trimmedNickname = formState.nickname.trim();
   const isNicknameChanged = trimmedNickname !== initialNickname;
-  const isPasswordChanged = formState.newPassword.length > 0;
+  const isPasswordChanged =
+    formState.newPassword.length > 0 || formState.confirmPassword.length > 0;
 
   const updateMeMutation = useMutation({
     mutationFn: (data: Auth.UpdateMeReq) => authService.updateMe(data),
@@ -89,6 +90,15 @@ export default function EditProfileForm({
     }
 
     if (isPasswordChanged) {
+      if (!newPassword) {
+        toast.warn('새 비밀번호를 입력해주세요.', { position: 'top-center' });
+        return;
+      }
+      if (!confirmPassword) {
+        toast.warn('비밀번호 확인을 입력해주세요.', { position: 'top-center' });
+        return;
+      }
+
       if (newPassword !== confirmPassword) {
         toast.warn('비밀번호가 일치하지 않습니다.', { position: 'top-center' });
         return;

--- a/src/domain/Mypage/AccountSetting/LogoutModal/LogoutModal.tsx
+++ b/src/domain/Mypage/AccountSetting/LogoutModal/LogoutModal.tsx
@@ -25,15 +25,7 @@ export default function LogoutModal({ isOpen, onClose }: LogoutModalProps) {
     authService.postLogout();
     clearUser();
     onClose();
-
-    // 로그아웃 성공 토스트 메시지 띄우기
-    toast.success('로그아웃 되었습니다.', {
-      position: 'top-center',
-      autoClose: 2000,
-      hideProgressBar: true,
-      closeOnClick: true,
-      pauseOnHover: false,
-    });
+    toast.success('로그아웃 되었습니다.');
     router.replace('/');
   };
 

--- a/src/domain/Mypage/AccountSetting/LogoutModal/LogoutModal.tsx
+++ b/src/domain/Mypage/AccountSetting/LogoutModal/LogoutModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
 import Modal from '@/shared/components/Modal/Modal';
 import Button from '@/shared/components/Button/Button';
 
@@ -14,6 +16,7 @@ interface LogoutModalProps {
 }
 
 export default function LogoutModal({ isOpen, onClose }: LogoutModalProps) {
+  const router = useRouter();
   const clearUser = useAuthStore(state => state.clearUser);
 
   if (!isOpen) return null;
@@ -22,6 +25,16 @@ export default function LogoutModal({ isOpen, onClose }: LogoutModalProps) {
     authService.postLogout();
     clearUser();
     onClose();
+
+    // 로그아웃 성공 토스트 메시지 띄우기
+    toast.success('로그아웃 되었습니다.', {
+      position: 'top-center',
+      autoClose: 2000,
+      hideProgressBar: true,
+      closeOnClick: true,
+      pauseOnHover: false,
+    });
+    router.replace('/');
   };
 
   return (

--- a/src/domain/Room/RoomEntryCard/RoomEntryCard.tsx
+++ b/src/domain/Room/RoomEntryCard/RoomEntryCard.tsx
@@ -27,15 +27,7 @@ export default function RoomEntryCard() {
   const handleTogetherClick = useCallback(() => {
     // 비로그인 상태 체크
     if (!user) {
-      // toast 알림 띄우기
-      toast.warn('같이 정하기는 로그인 후 이용할 수 있습니다.', {
-        position: 'top-center',
-        autoClose: 3000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-      });
+      toast.warn('같이 정하기는 로그인 후 이용할 수 있습니다.');
       return;
     }
 

--- a/src/domain/Room/RoomEntryCard/RoomEntryCard.tsx
+++ b/src/domain/Room/RoomEntryCard/RoomEntryCard.tsx
@@ -3,14 +3,14 @@
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { User, Users } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
+import { useAuthStore } from '@/domain/Auth/store/auth.store';
 import Button from '@/shared/components/Button/Button';
 import { useRoomEntry } from '../hooks/useRoomEntry';
 import RoomEntryModal from '../RoomEntryModal/RoomEntryModal';
 
 import styles from './RoomEntryCard.module.scss';
-import { authService } from '@/app/services/backend/auth.api';
 
 type Mode = 'together' | 'solo';
 
@@ -21,23 +21,28 @@ export default function RoomEntryCard() {
   const [mode, setMode] = useState<Mode>('together');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // handle together mode click
-  const { data: me } = useQuery({
-    queryKey: ['me'],
-    queryFn: () => authService.getMe(),
-    staleTime: Infinity,
-  });
+  // 실시간 유저 상태 (Zustand)
+  const user = useAuthStore(state => state.user);
 
   const handleTogetherClick = useCallback(() => {
-    if (!me) {
-      alert('같이 정하기는 로그인 후 이용할 수 있습니다.');
-      router.push('/');
+    // 비로그인 상태 체크
+    if (!user) {
+      // toast 알림 띄우기
+      toast.warn('같이 정하기는 로그인 후 이용할 수 있습니다.', {
+        position: 'top-center',
+        autoClose: 3000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+      });
       return;
-    } else {
-      setIsModalOpen(true);
-      room.setStep('select');
     }
-  }, [me, router, room]);
+
+    // 로그인 상태면 모달 열기
+    setIsModalOpen(true);
+    room.setStep('select');
+  }, [user, room]);
 
   return (
     <>
@@ -49,6 +54,7 @@ export default function RoomEntryCard() {
 
         <div className={styles['room-entry__tabs']}>
           <button
+            type="button"
             className={`${styles['room-entry__tab']} ${
               mode === 'together' ? styles['room-entry__tab--active'] : ''
             }`}
@@ -58,6 +64,7 @@ export default function RoomEntryCard() {
           </button>
 
           <button
+            type="button"
             className={`${styles['room-entry__tab']} ${
               mode === 'solo' ? styles['room-entry__tab--active'] : ''
             }`}

--- a/src/shared/components/Toast/GlobalToast.tsx
+++ b/src/shared/components/Toast/GlobalToast.tsx
@@ -4,18 +4,5 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 export default function GlobalToast() {
-  return (
-    <ToastContainer
-      position="top-center"
-      autoClose={2000}
-      hideProgressBar={false}
-      newestOnTop={false}
-      closeOnClick
-      rtl={false}
-      pauseOnFocusLoss
-      draggable
-      pauseOnHover
-      theme="light"
-    />
-  );
+  return <ToastContainer position="top-center" autoClose={2000} closeOnClick />;
 }

--- a/src/shared/components/Toast/GlobalToast.tsx
+++ b/src/shared/components/Toast/GlobalToast.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+export default function GlobalToast() {
+  return (
+    <ToastContainer
+      position="top-center"
+      autoClose={2000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme="light"
+    />
+  );
+}

--- a/src/shared/components/layout/Header/Header.tsx
+++ b/src/shared/components/layout/Header/Header.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useQuery } from '@tanstack/react-query';
 import { Menu, X } from 'lucide-react';
+import { toast } from 'react-toastify';
 
 import Button from '@/shared/components/Button';
 import LoginModal from '@/domain/Auth/LoginModal';
@@ -17,43 +18,33 @@ import WhatLunchLogo from '../../../../../public/icons/what-lunch-logo.svg';
 
 import styles from './Header.module.scss';
 
-// 닉네임에서 첫 글자 추출
 const getInitial = (nickname?: string) => {
   if (!nickname) return '?';
-
   const trimmed = nickname.trim();
   if (!trimmed) return '?';
-
   return Array.from(trimmed)[0];
 };
 
 export function Header() {
+  const router = useRouter();
   const [modalType, setModalType] = useState<'login' | 'signup' | null>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const { user, clearUser } = useAuthStore();
+  const { user, clearUser, isAuthLoading } = useAuthStore();
 
-  // TODO: 에러 TOAST 처리
-  const {
-    data: me,
-    isLoading: isAuthLoading,
-    // isError,
-    // error,
-  } = useQuery({
-    queryKey: ['me'],
-    queryFn: () => authService.getMe(),
-    enabled: !user,
-    staleTime: Infinity,
-  });
-
-  // 공통 로그아웃 핸들러
   const handleLogout = (afterLogout?: () => void) => {
-    const ok = confirm('로그아웃하시겠어요?');
-    if (!ok) return;
-
     authService.postLogout();
-    clearUser(); // 전역 auth 상태 초기화
-
+    clearUser();
     afterLogout?.();
+
+    toast.success('로그아웃 되었습니다.', {
+      position: 'top-center',
+      autoClose: 2000,
+      hideProgressBar: true,
+      closeOnClick: true,
+      pauseOnHover: false,
+    });
+
+    router.replace('/');
   };
 
   return (
@@ -62,13 +53,12 @@ export function Header() {
         <Link href="/">
           <span>홈</span>
         </Link>
-        {isAuthLoading
-          ? null
-          : me && (
-              <Link href="/mypage">
-                <span>마이페이지</span>
-              </Link>
-            )}
+
+        {!isAuthLoading && user && (
+          <Link href="/mypage">
+            <span>마이페이지</span>
+          </Link>
+        )}
 
         <Link href="/faq">
           <span>고객센터</span>
@@ -81,13 +71,14 @@ export function Header() {
       </Link>
 
       <div className={styles['header__auth']}>
-        {me ? (
+        {isAuthLoading ? (
+          <div style={{ width: '80px', height: '40px' }} />
+        ) : user ? (
           <>
             <div className={styles['header__user']}>
-              <div className={styles['header__user-avatar']}>{getInitial(me.nickname)}</div>
-              <span className={styles['header__user-nickname']}>{me.nickname || '사용자'}님</span>
+              <div className={styles['header__user-avatar']}>{getInitial(user.nickname)}</div>
+              <span className={styles['header__user-nickname']}>{user.nickname || '사용자'}님</span>
             </div>
-
             <Button variant="primary" onClick={() => handleLogout()}>
               로그아웃
             </Button>
@@ -108,7 +99,7 @@ export function Header() {
       {!isMobileMenuOpen && (
         <button
           className={styles['header__hamburger']}
-          onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          onClick={() => setIsMobileMenuOpen(true)}
           aria-label="메뉴 열기"
         >
           <Menu size={26} />
@@ -121,7 +112,7 @@ export function Header() {
           <div
             className={styles['header__mobile-overlay']}
             onClick={() => setIsMobileMenuOpen(false)}
-          ></div>
+          />
           <div className={styles['header__mobile-menu']}>
             <div className={styles['header__mobile-menu-header']}>
               <span className={styles['header__mobile-menu-title']}>메뉴</span>
@@ -140,34 +131,28 @@ export function Header() {
                   홈
                 </Link>
               </li>
-              <li>
-                <Link href="/mypage" onClick={() => setIsMobileMenuOpen(false)}>
-                  마이페이지
-                </Link>
-              </li>
+              {user && (
+                <li>
+                  <Link href="/mypage" onClick={() => setIsMobileMenuOpen(false)}>
+                    마이페이지
+                  </Link>
+                </li>
+              )}
               <li>
                 <Link href="/faq" onClick={() => setIsMobileMenuOpen(false)}>
                   고객센터
                 </Link>
               </li>
 
-              {/* 로그인 상태 */}
-              {!isAuthLoading && me && (
+              {isAuthLoading ? (
+                <li>잠시만 기다려주세요...</li>
+              ) : user ? (
                 <li>
-                  <button
-                    onClick={() =>
-                      handleLogout(() => {
-                        setIsMobileMenuOpen(false);
-                      })
-                    }
-                  >
+                  <button onClick={() => handleLogout(() => setIsMobileMenuOpen(false))}>
                     로그아웃
                   </button>
                 </li>
-              )}
-
-              {/* 비로그인 상태 */}
-              {!isAuthLoading && !me && (
+              ) : (
                 <>
                   <li>
                     <button
@@ -202,7 +187,6 @@ export function Header() {
           onSignupOpen={() => setModalType('signup')}
         />
       )}
-
       {modalType === 'signup' && (
         <SignupModal onClose={() => setModalType(null)} onLoginOpen={() => setModalType('login')} />
       )}

--- a/src/shared/components/layout/Header/Header.tsx
+++ b/src/shared/components/layout/Header/Header.tsx
@@ -35,14 +35,7 @@ export function Header() {
     authService.postLogout();
     clearUser();
     afterLogout?.();
-
-    toast.success('로그아웃 되었습니다.', {
-      position: 'top-center',
-      autoClose: 2000,
-      hideProgressBar: true,
-      closeOnClick: true,
-      pauseOnHover: false,
-    });
+    toast.success('로그아웃 되었습니다.');
 
     router.replace('/');
   };
@@ -98,6 +91,7 @@ export function Header() {
       {/* 햄버거 버튼 */}
       {!isMobileMenuOpen && (
         <button
+          type="button"
           className={styles['header__hamburger']}
           onClick={() => setIsMobileMenuOpen(true)}
           aria-label="메뉴 열기"
@@ -117,6 +111,7 @@ export function Header() {
             <div className={styles['header__mobile-menu-header']}>
               <span className={styles['header__mobile-menu-title']}>메뉴</span>
               <button
+                type="button"
                 className={styles['header__mobile-menu-close']}
                 onClick={() => setIsMobileMenuOpen(false)}
                 aria-label="메뉴 닫기"
@@ -131,7 +126,7 @@ export function Header() {
                   홈
                 </Link>
               </li>
-              {user && (
+              {!isAuthLoading && user && (
                 <li>
                   <Link href="/mypage" onClick={() => setIsMobileMenuOpen(false)}>
                     마이페이지
@@ -148,7 +143,10 @@ export function Header() {
                 <li>잠시만 기다려주세요...</li>
               ) : user ? (
                 <li>
-                  <button onClick={() => handleLogout(() => setIsMobileMenuOpen(false))}>
+                  <button
+                    type="button"
+                    onClick={() => handleLogout(() => setIsMobileMenuOpen(false))}
+                  >
                     로그아웃
                   </button>
                 </li>
@@ -156,6 +154,7 @@ export function Header() {
                 <>
                   <li>
                     <button
+                      type="button"
                       onClick={() => {
                         setModalType('login');
                         setIsMobileMenuOpen(false);
@@ -166,6 +165,7 @@ export function Header() {
                   </li>
                   <li>
                     <button
+                      type="button"
                       onClick={() => {
                         setModalType('signup');
                         setIsMobileMenuOpen(false);

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -14,6 +14,11 @@ namespace Auth {
   interface LoginRes {
     accessToken: string;
     expiresAt: string;
+    user: {
+      email: string;
+      nickname: string;
+      profileImage: string | null;
+    };
   }
 
   interface MeRes {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
### 1. 알림 UX 전면 개선 (react-toastify 도입) 기존의 투박하고 사용자 경험을 끊는 브라우저 기본 알림(alert, confirm)을 제거하고, 부드러운 토스트 메시지로 대체했습니다.
- Global: layout.tsx에 ToastContainer 및 CSS 스타일 설정 추가
- Auth: 로그인, 회원가입, 로그아웃 시 성공/실패/유효성 검사 메시지 적용
- MyPage: 프로필 수정(닉네임, 비밀번호) 시 성공/경고 알림 적용
- Room: 방 입장/생성 시 비로그인 안내 메시지 적용

### 2. 초기 로딩 최적화 (ClientWarmup 추가)
- 앱 초기 진입 시 필요한 백그라운드 작업을 처리하기 위한 ClientWarmup 컴포넌트를 추가하고 루트 레이아웃에 배치했습니다.
## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법
<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1.
2.
3.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
- 토스트 메시지는 top-center 위치에 2~3초간 노출되도록 설정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic authentication initialization on app startup
  * App-wide toast system with global toast UI

* **Improvements**
  * Replaced browser alerts with toasts across signup, login, profile edit, and logout flows
  * Smoother logout with success toast and automatic redirect to home
  * Header and mobile menu reflect authentication state more reliably
  * Room entry now warns via toast when login is required instead of immediate redirect
  * Form controls disable during submission to prevent duplicate actions
  * Login now provides and sets basic user profile info on success

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->