### PR TITLE
[refactor/cleanup-auth-logic] - 프론트엔드 쿠키 강제 설정 코드 삭제

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,36 +5,15 @@ const nextConfig = {
   sassOptions: {
     includePaths: [join(process.cwd(), 'src', 'styles')],
   },
+  // CORS 헤더 설정 부분은 삭제 Proxy 사용 시 불필요/충돌 위험
+
   async rewrites() {
     return [
       {
+        // 1. 프론트엔드에서 '/api/proxy/auth/login' 으로 요청하면
         source: '/api/proxy/:path*',
+        // 2. 실제로는 'https://backend-piik.onrender.com/auth/login' 으로 전송됨
         destination: 'https://backend-piik.onrender.com/:path*',
-      },
-    ];
-  },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'Access-Control-Allow-Credentials',
-            value: 'true',
-          },
-          {
-            key: 'Access-Control-Allow-Origin',
-            value: 'https://whatlunch.vercel.app',
-          },
-          {
-            key: 'Access-Control-Allow-Methods',
-            value: 'GET,POST,PUT,DELETE,OPTIONS',
-          },
-          {
-            key: 'Access-Control-Allow-Headers',
-            value: 'Content-Type,Authorization',
-          },
-        ],
       },
     ];
   },
@@ -46,7 +25,6 @@ const nextConfig = {
         port: '',
         pathname: '/img/wn/**',
       },
-
       {
         protocol: 'https',
         hostname: 'whatlunch-bucket.s3.ap-northeast-2.amazonaws.com',
@@ -54,11 +32,7 @@ const nextConfig = {
         pathname: '/**',
       },
     ],
-
-    domains: [
-      'lh3.googleusercontent.com',
-      // 필요시 다른 외부 이미지 도메인도 추가
-    ],
+    domains: ['lh3.googleusercontent.com'],
   },
 };
 

--- a/src/domain/Auth/LoginModal/LoginModal.tsx
+++ b/src/domain/Auth/LoginModal/LoginModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image'; // [추가] 이미지 사용을 위해 추가
+import Image from 'next/image';
 
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
@@ -43,8 +43,6 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
   const [password, setPassword] = useState('');
 
   const router = useRouter();
-  // [추가] 구글 로그인 버튼 제어를 위한 Ref
-
   const googleLoginButtonRef = useRef<HTMLDivElement>(null);
 
   const { setUser } = useAuthStore();
@@ -56,6 +54,7 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
 
       toast.success('로그인에 성공했습니다.');
       onClose();
+      // 데이터 갱신을 위한 새로고침
       setTimeout(() => {
         router.refresh();
       }, 100);
@@ -68,8 +67,15 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
   const googleLoginMutation = useMutation({
     mutationFn: (data: { idToken: string }) => authServiceClient.loginWithGoogle(data),
     onSuccess: res => {
+      // 백엔드가 Set-Cookie 헤더로 보내준 HttpOnly 쿠키가 브라우저에 자동 저장됩니다.
       setUser(res.user);
+      toast.success('구글 로그인에 성공했습니다.');
       onClose();
+
+      // 일반 로그인과 동일하게 부드러운 갱신 처리
+      setTimeout(() => {
+        router.refresh();
+      }, 100);
     },
     onError: () => {
       toast.error('구글 로그인에 실패했습니다.');

--- a/src/domain/Auth/LoginModal/LoginModal.tsx
+++ b/src/domain/Auth/LoginModal/LoginModal.tsx
@@ -50,6 +50,10 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
   const loginMutation = useMutation({
     mutationFn: (data: Auth.LoginReq) => authServiceClient.postLogin(data),
     onSuccess: res => {
+      if (res.accessToken) {
+        document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
+      }
+
       setUser(res.user);
 
       toast.success('로그인에 성공했습니다.');
@@ -67,12 +71,16 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
   const googleLoginMutation = useMutation({
     mutationFn: (data: { idToken: string }) => authServiceClient.loginWithGoogle(data),
     onSuccess: res => {
-      // 백엔드가 Set-Cookie 헤더로 보내준 HttpOnly 쿠키가 브라우저에 자동 저장됩니다.
+      // 프론트엔드 도메인에서 강제로 쿠키를 저장합니다.
+      if (res.accessToken) {
+        document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
+      }
+
       setUser(res.user);
       toast.success('구글 로그인에 성공했습니다.');
       onClose();
 
-      // 일반 로그인과 동일하게 부드러운 갱신 처리
+      // 로그인 상태 반영을 위해 새로고침
       setTimeout(() => {
         router.refresh();
       }, 100);

--- a/src/domain/Auth/SignupModal/SignupModal.tsx
+++ b/src/domain/Auth/SignupModal/SignupModal.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { GoogleLogin } from '@react-oauth/google';
+import { useRouter } from 'next/navigation';
 
 import Button from '@/shared/components/Button';
 import BaseInput from '@/shared/components/Input/BaseInput';
@@ -22,7 +23,7 @@ import styles from '../AuthModal.module.scss';
 export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) {
   const emailRef = useRef<HTMLInputElement>(null);
   const nicknameRef = useRef<HTMLInputElement>(null);
-
+  const router = useRouter();
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
 
@@ -58,6 +59,9 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
 
       toast.success('구글 계정으로 회원가입 및 로그인되었습니다!');
       onClose();
+      setTimeout(() => {
+        router.refresh();
+      }, 100);
     },
     onError: () => {
       toast.error('구글 회원가입에 실패했습니다.');

--- a/src/domain/Auth/SignupModal/SignupModal.tsx
+++ b/src/domain/Auth/SignupModal/SignupModal.tsx
@@ -54,6 +54,11 @@ export default function SignupModal({ onClose, onLoginOpen }: SignupModalProps) 
   const googleSignupMutation = useMutation({
     mutationFn: (data: { idToken: string }) => authServiceClient.loginWithGoogle(data),
     onSuccess: res => {
+      // 프론트엔드 도메인에서 강제로 쿠키를 저장합니다.
+      if (res.accessToken) {
+        document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
+      }
+
       // 성공 시 바로 로그인
       setUser(res.user);
 

--- a/src/shared/components/layout/Header/HeaderClient.tsx
+++ b/src/shared/components/layout/Header/HeaderClient.tsx
@@ -18,7 +18,6 @@ import { useAuthStore } from '@/domain/Auth/store/auth.store';
 import { disconnectSocket } from '@/app/lib/socket';
 
 import WhatLunchLogo from '../../../../../public/icons/what-lunch-logo.svg';
-
 import styles from './Header.module.scss';
 
 export default function HeaderClient({ user: initialUser }: { user: Auth.MeRes | null }) {
@@ -28,17 +27,21 @@ export default function HeaderClient({ user: initialUser }: { user: Auth.MeRes |
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
-  const { user: storeUser, clearUser, setUser } = useAuthStore();
+  const storeUser = useAuthStore(state => state.user);
+  const clearUser = useAuthStore(state => state.clearUser);
 
   useEffect(() => {
     if (initialUser) {
-      setUser(initialUser);
+      useAuthStore.setState(state => ({
+        ...state,
+        user: initialUser,
+      }));
     } else {
       clearUser();
     }
-  }, [initialUser, setUser, clearUser]);
+  }, [initialUser, clearUser]);
 
-  const displayUser = storeUser || initialUser;
+  const displayUser = storeUser ?? initialUser;
 
   const handleLogout = useCallback(async () => {
     try {
@@ -47,7 +50,6 @@ export default function HeaderClient({ user: initialUser }: { user: Auth.MeRes |
       await authServiceClient.postLogout();
       disconnectSocket();
       queryClient.clear();
-
       clearUser();
 
       toast.success('로그아웃 되었습니다.');


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 임시 수동 쿠키 설정 제거
- 백엔드의 trust proxy 설정이 완료됨에 따라, 프론트엔드에서 임시로 사용하던 document.cookie 강제 주입 코드를 삭제
- 이제 보안상 더 안전한 백엔드의 Set-Cookie (HttpOnly, Secure) 헤더를 통해 쿠키가 자동 저장됩니다. (XSS 취약점 해결)

## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1.
2.
3.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
이 PR은 백엔드의 trust proxy 및 NODE_ENV=production 설정이 적용된 상태에서만 정상 작동합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인·구글 로그인/가입 성공 시 토스트 알림 표시, 모달 자동 닫힘 및 짧은 지연 후 UI 자동 새로고침 적용

* **개선 사항**
  * 구글 인증 흐름에서 액세스 토큰 처리로 인증 후 상태 반영 안정성 향상
  * 외부 이미지 도메인 목록 정리로 프로필 이미지 로드 신뢰성 개선
  * 헤더 관련 인증 상태 초기화 및 표시 로직 정리로 로그아웃/초기 사용자 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->