### PR TITLE
[fix/roompage-breakpoints] - 방페이지 반응형 추가 및 룰렛 결과 지도 반영

### DIFF
--- a/src/app/rooms/[roomId]/page.module.scss
+++ b/src/app/rooms/[roomId]/page.module.scss
@@ -4,12 +4,11 @@
 .room {
   width: 100%;
   height: 100%;
-  padding: 38px 24px;
   @include m.flex-box(flex-start, stretch, column);
   gap: 20px;
 
   &__header {
-    @include m.flex-box(space-between, center);
+    @include m.flex-box(space-between, flex-start, column);
     gap: 16px;
     padding: 20px 24px;
     background: linear-gradient(135deg, f.color(purple-50) 0%, f.color(purple-100) 100%);
@@ -17,6 +16,10 @@
     border: 2px solid rgba(f.color(purple-600), 0.15);
     box-shadow: 0 8px 32px rgba(f.color(purple-600), 0.12);
     transition: all 0.3s ease;
+
+    @include m.mq(md) {
+      @include m.flex-box(space-between, center);
+    }
 
     &:hover {
       box-shadow: 0 12px 40px rgba(f.color(purple-600), 0.18);
@@ -41,21 +44,30 @@
   }
 
   &__title {
-    @include m.text-style('xl', 700);
+    @include m.text-style('md', 700);
     background: linear-gradient(135deg, f.color(purple-700) 0%, f.color(purple-500) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+
+    @include m.mq(md) {
+      @include m.text-style('xl', 700);
+    }
   }
 
   &__subtitle {
-    @include m.text-style('sm', 500);
+    @include m.text-style('xs', 500);
     color: rgba(f.color(purple-700), 0.7);
     margin-top: 4px;
+
+    @include m.mq(md) {
+      @include m.text-style('sm', 500);
+    }
   }
 
   &__code {
-    @include m.flex-box(flex-start, center);
+    width: 100%;
+    @include m.flex-box(space-between, center);
     gap: 10px;
     padding: 8px 16px;
     border-radius: 999px;
@@ -64,15 +76,24 @@
     border: 2px solid rgba(f.color(purple-600), 0.2);
     box-shadow: 0 4px 12px rgba(f.color(purple-600), 0.15);
 
+    @include m.mq(md) {
+      width: fit-content;
+    }
+
     &__label {
       @include m.text-style('xs', 600);
       color: rgba(f.color(purple-700), 0.7);
     }
 
     &__value {
-      @include m.text-style('sm', 700);
-      letter-spacing: 0.1em;
-      color: f.color(purple-700);
+      @include m.flex-box(space-between, center);
+      gap: 16px;
+
+      &__inner {
+        @include m.text-style('sm', 700);
+        letter-spacing: 0.1em;
+        color: f.color(purple-700);
+      }
     }
 
     &__copy {
@@ -101,21 +122,24 @@
   }
 
   &__content {
-    height: calc(100vh - 370px);
+    height: fit-content;
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 0.7fr;
+
     gap: 20px;
     width: 100%;
-    margin-bottom: 20px;
+
+    @include m.mq(lg) {
+      grid-template-columns: 2fr 1fr;
+      grid-template-rows: none;
+    }
   }
 
   &__roulette-section {
-    @include m.flex-box(flex-start, stretch, column);
     background: linear-gradient(135deg, #fdfcff 0%, #faf8ff 100%);
     border-radius: 24px;
     border: 2px solid rgba(f.color(purple-600), 0.15);
     box-shadow: 0 8px 32px rgba(f.color(purple-600), 0.12);
-    padding: 28px;
     transition: all 0.3s ease;
 
     &:hover {
@@ -126,14 +150,17 @@
 
   &__stats {
     width: 100%;
-
     @include m.flex-box(flex-start, stretch, column);
 
     &__inner {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
       gap: 18px;
       width: 100%;
+
+      @include m.mq(lg) {
+        grid-template-columns: 1fr 1fr;
+      }
     }
   }
 
@@ -392,7 +419,7 @@
 
   &__right {
     width: 100%;
-    height: 100%;
+    height: inherit;
     flex: 1;
     background: linear-gradient(135deg, f.color(purple-50) 0%, f.color(purple-100) 100%);
     border-radius: 24px;
@@ -402,6 +429,9 @@
     overflow: hidden;
     transition: all 0.3s ease;
 
+    @include m.mq(lg) {
+      height: 100%;
+    }
     &:hover {
       box-shadow: 0 12px 40px rgba(f.color(purple-600), 0.18);
     }

--- a/src/app/rooms/[roomId]/page.tsx
+++ b/src/app/rooms/[roomId]/page.tsx
@@ -8,9 +8,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import RoomTabs from '@/shared/components/RoomTabs';
 import Chat from '@/domain/Chat';
 import FavoriteToggle from '@/shared/components/FavoriteToggle';
-import KakaoMap from '@/shared/components/KakaoMap/KakaoMap';
-import Button from '@/shared/components/Button/Button';
-import BaseInput from '@/shared/components/Input/BaseInput/BaseInput';
+import KakaoMap from '@/shared/components/KakaoMap';
+import Button from '@/shared/components/Button';
+import BaseInput from '@/shared/components/Input/BaseInput';
 import Loading from '@/shared/components/Loading';
 
 import { useAuthStore } from '@/domain/Auth/store/auth.store';

--- a/src/app/rooms/[roomId]/page.tsx
+++ b/src/app/rooms/[roomId]/page.tsx
@@ -54,7 +54,6 @@ export default function RoomPage({ params }: RoomPageProps) {
     const fetchFavorites = async () => {
       try {
         const favorites = await favoritesServiceClient.getMyFavorites();
-        console.log('찜한 메뉴:', favorites);
         const favMap: Record<string, boolean> = {};
         favorites.forEach(menu => {
           favMap[menu._id] = true;
@@ -192,16 +191,18 @@ export default function RoomPage({ params }: RoomPageProps) {
 
         <div className={styles['room__code']}>
           <span className={styles['room__code__label']}>방 코드</span>
-          <strong className={styles['room__code__value']}>{roomId}</strong>
-          <button
-            type="button"
-            aria-label="방 코드 복사"
-            className={styles['room__code__copy']}
-            onClick={copyRoomCode}
-          >
-            {copied ? <Check size={16} /> : <Copy size={16} />}
-            {copied ? '복사됨' : '복사'}
-          </button>
+          <div className={styles['room__code__value']}>
+            <strong className={styles['room__code__value__inner']}>{roomId}</strong>
+            <button
+              type="button"
+              aria-label="방 코드 복사"
+              className={styles['room__code__copy']}
+              onClick={copyRoomCode}
+            >
+              {copied ? <Check size={16} /> : <Copy size={16} />}
+              {copied ? '복사됨' : '복사'}
+            </button>
+          </div>
         </div>
       </header>
 

--- a/src/app/rooms/solo/page.module.scss
+++ b/src/app/rooms/solo/page.module.scss
@@ -57,12 +57,6 @@
         }
       }
     }
-
-    &__stats {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-    }
   }
 
   &__content {
@@ -74,12 +68,16 @@
 
   &__main-section {
     display: flex;
+    flex-direction: column;
     gap: 24px;
     width: 100%;
+
+    @include m.mq(xl) {
+      flex-direction: row;
+    }
   }
 
   &__left {
-    flex: 0 0 60%;
     @include m.flex-box(center, center);
     background: linear-gradient(135deg, #fdfcff 0%, #faf8ff 100%);
     border-radius: 24px;
@@ -96,7 +94,7 @@
   }
 
   &__right {
-    flex: 0 0 40%;
+    width: 100%;
   }
 
   &__map-section {

--- a/src/app/rooms/solo/page.module.scss
+++ b/src/app/rooms/solo/page.module.scss
@@ -83,10 +83,13 @@
     border-radius: 24px;
     border: 2px solid rgba(f.color(purple-600), 0.15);
     box-shadow: 0 8px 32px rgba(f.color(purple-600), 0.12);
-    padding: 32px;
+    padding: 0px;
     min-height: 500px;
     transition: all 0.3s ease;
 
+    @include m.mq(md) {
+      padding: 32px;
+    }
     &:hover {
       box-shadow: 0 12px 40px rgba(f.color(purple-600), 0.18);
       transform: translateY(-2px);

--- a/src/app/rooms/solo/page.tsx
+++ b/src/app/rooms/solo/page.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { DicesIcon, Clock } from 'lucide-react';
 import { toast } from 'react-toastify';
 
-import Roulette from '@/domain/Roulette/Roulette';
+import Roulette from '@/domain/Roulette';
 import KakaoMap from '@/shared/components/KakaoMap';
 import { BaseInput } from '@/shared/components/Input';
 import Button from '@/shared/components/Button';

--- a/src/app/rooms/solo/page.tsx
+++ b/src/app/rooms/solo/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StarIcon, DicesIcon, Clock } from 'lucide-react';
+import { DicesIcon, Clock } from 'lucide-react';
 import { toast } from 'react-toastify';
 
 import Roulette from '@/domain/Roulette/Roulette';
 import KakaoMap from '@/shared/components/KakaoMap';
-import Badge, { BadgeProps } from '@/shared/components/Badge';
 import { BaseInput } from '@/shared/components/Input';
 import Button from '@/shared/components/Button';
 import FavoriteToggle from '@/shared/components/FavoriteToggle';
@@ -17,10 +16,6 @@ import { useRouletteResultStore } from '@/shared/stores/rouletteResultStore';
 import { useAuthStore } from '@/domain/Auth/store/auth.store';
 
 import styles from './page.module.scss';
-
-const BADGES: BadgeProps[] = [
-  { id: 'top-menu', variant: 'green', Icon: StarIcon, text: '현재 1등 메뉴: 치킨' },
-];
 
 export default function SoloRoomPage() {
   const [isSpinning, setIsSpinning] = useState(false);
@@ -125,12 +120,6 @@ export default function SoloRoomPage() {
               <h2>혼자 메뉴 정하기</h2>
               <span>혼자서도 룰렛을 돌릴 수 있어요!</span>
             </div>
-          </div>
-
-          <div className={styles['solo__header__stats']}>
-            {BADGES.map(({ id, variant, Icon, text }) => (
-              <Badge key={id} id={id} variant={variant} Icon={Icon} text={text} />
-            ))}
           </div>
         </header>
 

--- a/src/domain/Chat/Chat.module.scss
+++ b/src/domain/Chat/Chat.module.scss
@@ -22,7 +22,7 @@
 
   &__content {
     flex: 1;
-    min-height: 300px;
+    min-height: 200px;
     overflow-y: auto;
     padding: 20px;
     @include m.flex-box(flex-start, stretch, column);
@@ -30,6 +30,9 @@
     background: rgba(255, 255, 255, 0.3);
     backdrop-filter: blur(10px);
 
+    @include m.mq(lg) {
+      min-height: 300px;
+    }
     /* Custom scrollbar */
     &::-webkit-scrollbar {
       width: 6px;

--- a/src/domain/Roulette/Roulette.module.scss
+++ b/src/domain/Roulette/Roulette.module.scss
@@ -4,7 +4,7 @@
 .roulette {
   @include m.flex-box(center, center, column);
   gap: 14px;
-  width: max-content;
+  width: 100%;
   padding: 20px 0;
 
   &__today {
@@ -22,9 +22,6 @@
     position: relative;
     width: fit-content;
     margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
   }
 
   &__result-btn-wrapper {

--- a/src/domain/Roulette/Roulette.module.scss
+++ b/src/domain/Roulette/Roulette.module.scss
@@ -24,11 +24,21 @@
     margin: 0 auto;
   }
 
-  &__result-btn-wrapper {
+  &__result-btn {
     width: 100%;
-    margin-top: 6px;
-    margin-bottom: 8px;
+    margin: 6px auto;
     @include m.flex-box(center, center);
+
+    &__button {
+      width: 100px;
+      @include m.text-style('xs', 700);
+      padding: 8px;
+
+      @include m.mq(md) {
+        @include m.text-style('md', 700);
+        padding: 8px;
+      }
+    }
   }
 
   &__shuffle-btn {
@@ -46,10 +56,7 @@
 
     cursor: pointer;
 
-    transition:
-      background 0.15s ease,
-      transform 0.15s ease,
-      border-color 0.15s ease;
+    transition: all 0.2s ease;
 
     &:hover:not(:disabled) {
       background: f.color(gray-200);

--- a/src/domain/Roulette/Roulette.tsx
+++ b/src/domain/Roulette/Roulette.tsx
@@ -170,12 +170,13 @@ export const Roulette = memo(function Roulette({
         )}
       </div>
 
-      <div className={styles['roulette__result-btn-wrapper']}>
+      <div className={styles['roulette__result-btn']}>
         <Button
           variant="neutral"
           mode="fill"
           disabled={!localResult}
           onClick={() => setModalOpen(true)}
+          className={styles['roulette__result-btn__button']}
         >
           결과 보기
         </Button>

--- a/src/domain/Roulette/components/RouletteFilter/RouletteFilter.module.scss
+++ b/src/domain/Roulette/components/RouletteFilter/RouletteFilter.module.scss
@@ -12,28 +12,29 @@
     border-radius: 32px;
 
     &__tab {
-      width: 260px;
-      height: 48px;
-
+      width: 100px;
+      height: 36px;
       @include m.flex-box(center, center);
-      @include m.text-style(lg, 600);
-
+      @include m.text-style(md, 600);
       background: transparent;
-      border: none;
       border-radius: 32px;
-
       color: f.color(text-default);
-
       cursor: pointer;
-      transition:
-        background 0.25s ease,
-        color 0.25s ease,
-        transform 0.25s ease;
+      transition: all 0.2s ease;
+
+      @include m.mq(md) {
+        width: 200px;
+        height: 36px;
+      }
+      @include m.mq(lg) {
+        @include m.text-style(lg, 600);
+        width: 260px;
+        height: 48px;
+      }
 
       &--active {
         background: f.color(point-blue);
         color: f.color(text-inverse);
-
         box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
         transform: translateY(-2px);
       }
@@ -42,22 +43,25 @@
 
   &__options {
     margin-top: 20px;
-
     @include m.flex-box(center, center, row);
     flex-wrap: wrap;
-
     gap: 12px;
     width: 100%;
     padding: 0 12px;
 
     &__item {
       @include m.flex-box(center, center);
-      @include m.text-style(md, 400);
-
       border-radius: 16px;
-      height: 40px;
-      padding: 0 18px;
+      @include m.text-style(xs, 400);
+      height: 32px;
+      padding: 0 12px;
       box-sizing: border-box;
+
+      @include m.mq(lg) {
+        @include m.text-style(md, 400);
+        height: 40px;
+        padding: 0 18px;
+      }
 
       &__icon {
         @include m.flex-box(center, center);

--- a/src/domain/Roulette/components/RouletteFilter/RouletteFilter.module.scss
+++ b/src/domain/Roulette/components/RouletteFilter/RouletteFilter.module.scss
@@ -7,7 +7,6 @@
     width: fit-content;
     margin: 0 auto;
     padding: 4px;
-
     background: f.color(gray-100);
     border-radius: 32px;
 
@@ -26,6 +25,7 @@
         width: 200px;
         height: 36px;
       }
+
       @include m.mq(lg) {
         @include m.text-style(lg, 600);
         width: 260px;
@@ -44,10 +44,14 @@
   &__options {
     margin-top: 20px;
     @include m.flex-box(center, center, row);
+    gap: 8px;
     flex-wrap: wrap;
-    gap: 12px;
     width: 100%;
     padding: 0 12px;
+
+    @include m.mq(md) {
+      gap: 12px;
+    }
 
     &__item {
       @include m.flex-box(center, center);
@@ -56,6 +60,12 @@
       height: 32px;
       padding: 0 12px;
       box-sizing: border-box;
+
+      @include m.mq(md) {
+        @include m.text-style(sm, 400);
+        height: 36px;
+        padding: 0 14px;
+      }
 
       @include m.mq(lg) {
         @include m.text-style(md, 400);

--- a/src/domain/Roulette/components/RouletteUi/RouletteUi.module.scss
+++ b/src/domain/Roulette/components/RouletteUi/RouletteUi.module.scss
@@ -1,8 +1,8 @@
+@use 'utils/mixins' as m;
+@use 'utils/functions' as f;
+
 .roulette-ui {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  @include m.flex-box(center, center, column);
   padding: 20px;
   position: relative;
   min-height: auto;
@@ -13,7 +13,7 @@
   top: -40px;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 40px;
+  font-size: 24px;
   color: #ff4757;
   z-index: 10;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);

--- a/src/domain/Roulette/components/RouletteUi/RouletteUi.module.scss
+++ b/src/domain/Roulette/components/RouletteUi/RouletteUi.module.scss
@@ -3,9 +3,13 @@
 
 .roulette-ui {
   @include m.flex-box(center, center, column);
-  padding: 20px;
+  padding: 0px;
   position: relative;
   min-height: auto;
+
+  @include m.mq(md) {
+    padding: 20px;
+  }
 }
 
 .roulette-pointer {

--- a/src/domain/Roulette/components/RouletteUi/RouletteUi.tsx
+++ b/src/domain/Roulette/components/RouletteUi/RouletteUi.tsx
@@ -156,18 +156,28 @@ export default function RouletteUi({
 
   // 화면 크기 변경 대응
   useEffect(() => {
+    let resizeTimeout: NodeJS.Timeout | null = null;
+
     const handleResize = () => {
+      if (spinning) return;
       const smallerDimension = Math.min(window.innerWidth, window.innerHeight);
       const newSize = Math.floor(smallerDimension * 0.4);
-      setSize(newSize);
+      const clampedSize = Math.max(200, Math.min(600, newSize));
+      setSize(clampedSize);
     };
 
-    window.addEventListener('resize', handleResize);
+    const debouncedResize = () => {
+      if (resizeTimeout) clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(handleResize, 150);
+    };
+
+    window.addEventListener('resize', debouncedResize);
     handleResize();
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('resize', debouncedResize);
+      if (resizeTimeout) clearTimeout(resizeTimeout);
     };
-  }, []);
+  }, [spinning]);
 
   const canvasClass = spinning
     ? `${styles['roulette-ui__canvas']} ${styles['roulette-ui__canvas--spinning']}`

--- a/src/domain/Roulette/components/RouletteUi/RouletteUi.tsx
+++ b/src/domain/Roulette/components/RouletteUi/RouletteUi.tsx
@@ -20,7 +20,7 @@ interface RouletteUiProps {
     context?: Context[];
   };
   userRole?: 'host' | 'guest' | null;
-  size?: number;
+  // size?: number;
   disabled?: boolean;
   menusReady?: boolean;
 }
@@ -31,13 +31,14 @@ export default function RouletteUi({
   onResult,
   filters = {},
   userRole,
-  size = 480,
+  // size = 480,
   disabled = false,
   menusReady = true,
 }: RouletteUiProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
 
+  const [size, setSize] = useState(480);
   const [angle, setAngle] = useState(0);
   const [spinning, setSpinning] = useState(false);
 
@@ -152,6 +153,21 @@ export default function RouletteUi({
     disabled,
     menusReady,
   ]);
+
+  // 화면 크기 변경 대응
+  useEffect(() => {
+    const handleResize = () => {
+      const smallerDimension = Math.min(window.innerWidth, window.innerHeight);
+      const newSize = Math.floor(smallerDimension * 0.4);
+      setSize(newSize);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   const canvasClass = spinning
     ? `${styles['roulette-ui__canvas']} ${styles['roulette-ui__canvas--spinning']}`

--- a/src/domain/Roulette/constants/rouletteStyle.ts
+++ b/src/domain/Roulette/constants/rouletteStyle.ts
@@ -3,7 +3,7 @@ export const ROULETTE_STYLE = {
     color: '#334155',
     large: '700 28px Pretendard, sans-serif',
     normal: '600 20px Pretendard, sans-serif',
-    offsetRatio: 0.45,
+    offsetRatio: 0.5,
   },
 
   stroke: {

--- a/src/domain/Roulette/constants/rouletteStyle.ts
+++ b/src/domain/Roulette/constants/rouletteStyle.ts
@@ -15,6 +15,11 @@ export const ROULETTE_STYLE = {
     color: '#ef4444',
     size: 48,
     margin: 4,
+    responsive: {
+      mobile: 24 as number,
+      tablet: 32 as number,
+      desktop: 48 as number,
+    },
   },
 
   wheel: {

--- a/src/domain/Roulette/hooks/useRouletteDraw.ts
+++ b/src/domain/Roulette/hooks/useRouletteDraw.ts
@@ -115,10 +115,8 @@ export function useRouletteDraw(items: Menu.GetMenuRes[], size: number, sectorCo
       canvasContext.lineTo(pointerSize / 2, edge);
       canvasContext.lineTo(0, edge + triangleHeight);
       canvasContext.closePath();
-
       canvasContext.fillStyle = ROULETTE_STYLE.pointer.color;
       canvasContext.fill();
-
       canvasContext.restore();
     },
     [radius, size]

--- a/src/domain/Roulette/hooks/useRouletteDraw.ts
+++ b/src/domain/Roulette/hooks/useRouletteDraw.ts
@@ -4,8 +4,31 @@ import { ROULETTE_STYLE } from '../constants/rouletteStyle';
 
 const FULL_ANGLE = Math.PI * 2;
 
+function getResponsiveTextStyle(size: number): { large: string; normal: string } {
+  if (size < 300) {
+    // 모바일
+    return {
+      large: '700 16px Pretendard, sans-serif',
+      normal: '600 12px Pretendard, sans-serif',
+    };
+  } else if (size < 450) {
+    // 태블릿
+    return {
+      large: '700 22px Pretendard, sans-serif',
+      normal: '600 16px Pretendard, sans-serif',
+    };
+  } else {
+    // 데스크톱
+    return {
+      large: '700 28px Pretendard, sans-serif',
+      normal: '600 20px Pretendard, sans-serif',
+    };
+  }
+}
+
 export function useRouletteDraw(items: Menu.GetMenuRes[], size: number, sectorColors: string[]) {
   const radius = useMemo(() => size / 2, [size]);
+  const responsiveText = useMemo(() => getResponsiveTextStyle(size), [size]);
 
   const stepAngle = useMemo(() => {
     return items.length > 0 ? FULL_ANGLE / items.length : 0;
@@ -22,13 +45,13 @@ export function useRouletteDraw(items: Menu.GetMenuRes[], size: number, sectorCo
       canvasContext.save();
       canvasContext.translate(radius, radius);
       canvasContext.fillStyle = ROULETTE_STYLE.text.color;
-      canvasContext.font = ROULETTE_STYLE.text.large;
+      canvasContext.font = responsiveText.large;
       canvasContext.textAlign = 'center';
       canvasContext.textBaseline = 'middle';
       canvasContext.fillText(items[0].name, 0, 0);
       canvasContext.restore();
     },
-    [items, sectorColors, radius]
+    [items, sectorColors, radius, responsiveText]
   );
 
   // 섹터 + 텍스트 렌더링
@@ -56,7 +79,7 @@ export function useRouletteDraw(items: Menu.GetMenuRes[], size: number, sectorCo
         canvasContext.rotate(start + stepAngle / 2);
 
         canvasContext.fillStyle = ROULETTE_STYLE.text.color;
-        canvasContext.font = ROULETTE_STYLE.text.normal;
+        canvasContext.font = responsiveText.normal;
         canvasContext.textAlign = 'center';
         canvasContext.textBaseline = 'middle';
 
@@ -67,22 +90,29 @@ export function useRouletteDraw(items: Menu.GetMenuRes[], size: number, sectorCo
         canvasContext.restore();
       });
     },
-    [items, sectorColors, radius, stepAngle]
+    [items, sectorColors, radius, stepAngle, responsiveText]
   );
 
-  // 포인터 렌더링
+  // 포인터 렌더링 (반응형 크기)
   const drawPointer = useCallback(
     (canvasContext: CanvasRenderingContext2D) => {
       canvasContext.save();
       canvasContext.translate(radius, radius);
 
-      const side = ROULETTE_STYLE.pointer.size;
+      // 반응형 포인터 크기
+      let pointerSize = ROULETTE_STYLE.pointer.responsive.mobile;
+      if (size >= 450) {
+        pointerSize = ROULETTE_STYLE.pointer.responsive.desktop;
+      } else if (size >= 300) {
+        pointerSize = ROULETTE_STYLE.pointer.responsive.tablet;
+      }
+
       const edge = -(radius - ROULETTE_STYLE.pointer.margin);
-      const triangleHeight = (side * Math.sqrt(3)) / 2;
+      const triangleHeight = (pointerSize * Math.sqrt(3)) / 2;
 
       canvasContext.beginPath();
-      canvasContext.moveTo(-side / 2, edge);
-      canvasContext.lineTo(side / 2, edge);
+      canvasContext.moveTo(-pointerSize / 2, edge);
+      canvasContext.lineTo(pointerSize / 2, edge);
       canvasContext.lineTo(0, edge + triangleHeight);
       canvasContext.closePath();
 
@@ -91,7 +121,7 @@ export function useRouletteDraw(items: Menu.GetMenuRes[], size: number, sectorCo
 
       canvasContext.restore();
     },
-    [radius]
+    [radius, size]
   );
 
   // 전체 draw 함수

--- a/src/shared/components/KakaoMap/KakaoMap.tsx
+++ b/src/shared/components/KakaoMap/KakaoMap.tsx
@@ -93,6 +93,11 @@ function KakaoMap({ keyword, list = true, className = '' }: KakaoMapProps) {
     (data: Kakao.PlacesSearchResult) => {
       setPlaces(data);
 
+      if (data.length > 0 && mapRef.current) {
+        const first = data[0];
+        const position = new window.kakao.maps.LatLng(Number(first.y), Number(first.x));
+        mapRef.current.setCenter(position);
+      }
       // 이전 리스너 제거
       markerClickListenersRef.current.forEach(({ marker, listener }) => {
         window.kakao.maps.event.removeListener(marker, 'click', listener);

--- a/src/shared/components/KakaoMap/index.ts
+++ b/src/shared/components/KakaoMap/index.ts
@@ -1,2 +1,2 @@
 export { default } from './KakaoMap';
-export type { KakaoMapProps } from './types';
+export type * from './types';


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
1. 전체적인 스타일이 수정되었습니다. 
2. 기존 룰렛 돌리고 난 후 지도 마커표시가 되지 않던 오류 수정하였습니다. (룰렛 돌리면 해당 첫번째 결과로 지도 마커가 이동합니다)

## 📸 스크린샷

<img width="1131" height="1302" alt="image" src="https://github.com/user-attachments/assets/add0fa69-00cb-4dd7-93b5-844cc578a22e" />


## 🛠️ 테스트 방법

1.
3.
4.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 검색 결과 수신 시 자동으로 첫 번째 위치로 센터링

* **스타일/UI 개선**
  * 룸(개별·솔로) 화면 레이아웃 및 타이포그래피의 반응형 재정비
  * 솔로 페이지 상단 배지 제거로 헤더 간결화
  * 룰렛: 휠 크기 자동 조정, 포인터·텍스트의 반응형 크기 및 버튼/간격 조정
  * 룸 코드 표시 및 복사 영역의 배치·타이포그래피 개선
  * 채팅 콘텐츠 최소 높이 조정으로 레이아웃 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->