### PR TITLE
[fix/socket-chat] - 웹소켓 쿠키전달

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -31,8 +31,13 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
-    domains: ['lh3.googleusercontent.com'],
   },
 };
 

--- a/src/app/lib/fetcher-client.ts
+++ b/src/app/lib/fetcher-client.ts
@@ -21,7 +21,6 @@ async function refreshAccessToken(): Promise<boolean> {
         'Content-Type': 'application/json',
       },
     });
-    console.log('토큰 리프레시 응답:', res);
     return res.ok;
   } catch (error) {
     console.error('[FetcherClient] Refresh 실패:', error);

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -23,7 +23,8 @@ export const createSocket = (): Socket | null => {
 
   try {
     const apiUrl = getSocketUrl();
-    const rawToken =
+
+    const accessToken =
       typeof document !== 'undefined'
         ? document.cookie
             .split('; ')
@@ -33,14 +34,11 @@ export const createSocket = (): Socket | null => {
             .join('=')
         : undefined;
 
-    const cookies = document.cookie.split('; ');
-    console.log(cookies);
-    console.log('[Socket] rawToken:', rawToken ? rawToken.substring(0, 10) + '...' : 'none');
-    const accessToken = rawToken ? decodeURIComponent(rawToken) : undefined;
     console.log(
       '[Socket] accessToken:',
       accessToken ? accessToken.substring(0, 10) + '...' : 'none'
     );
+
     const socketOptions: Parameters<typeof io>[1] = {
       path: '/socket.io',
       transports: ['websocket', 'polling'],
@@ -54,11 +52,11 @@ export const createSocket = (): Socket | null => {
       },
     };
 
-    if (accessToken) {
-      socketOptions.auth = { token: accessToken };
-    }
-
     socket = io(apiUrl, socketOptions);
+
+    socket.on('connect', () => {
+      console.log('[Socket] 웹소켓 연결 성공');
+    });
 
     socket.on('connect_error', error => {
       console.error('[Socket] 연결 오류:', error);

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -34,11 +34,6 @@ export const createSocket = (): Socket | null => {
             .join('=')
         : undefined;
 
-    console.log(
-      '[Socket] accessToken:',
-      accessToken ? accessToken.substring(0, 10) + '...' : 'none'
-    );
-
     const socketOptions: Parameters<typeof io>[1] = {
       path: '/socket.io',
       transports: ['websocket', 'polling'],
@@ -53,10 +48,6 @@ export const createSocket = (): Socket | null => {
     };
 
     socket = io(apiUrl, socketOptions);
-
-    socket.on('connect', () => {
-      console.log('[Socket] 웹소켓 연결 성공');
-    });
 
     socket.on('connect_error', error => {
       console.error('[Socket] 연결 오류:', error);

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -24,12 +24,19 @@ export const createSocket = (): Socket | null => {
   try {
     const apiUrl = getSocketUrl();
 
-    const accessToken = document.cookie
-      .split('; ')
-      .find(row => row.startsWith('accessToken='))
-      ?.split('=')[1];
+    const rawToken =
+      typeof document !== 'undefined'
+        ? document.cookie
+            .split('; ')
+            .find(row => row.startsWith('accessToken='))
+            ?.split('=')
+            .slice(1)
+            .join('=')
+        : undefined;
 
-    socket = io(apiUrl, {
+    const accessToken = rawToken ? decodeURIComponent(rawToken) : undefined;
+
+    const socketOptions: Parameters<typeof io>[1] = {
       path: '/socket.io',
       transports: ['websocket'],
       withCredentials: true,
@@ -37,18 +44,20 @@ export const createSocket = (): Socket | null => {
       reconnectionDelay: 1000,
       reconnectionDelayMax: 5000,
       reconnectionAttempts: 5,
-      auth: {
-        token: accessToken,
-      },
+    };
 
-      transportOptions: {
+    if (accessToken) {
+      socketOptions.auth = { token: accessToken };
+      socketOptions.transportOptions = {
         websocket: {
           extraHeaders: {
             Cookie: `accessToken=${accessToken}`,
           },
         },
-      },
-    });
+      };
+    }
+
+    socket = io(apiUrl, socketOptions);
 
     socket.on('connect_error', error => {
       console.error('[Socket] 연결 오류:', error);

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -24,6 +24,11 @@ export const createSocket = (): Socket | null => {
   try {
     const apiUrl = getSocketUrl();
 
+    const accessToken = document.cookie
+      .split('; ')
+      .find(row => row.startsWith('accessToken='))
+      ?.split('=')[1];
+
     socket = io(apiUrl, {
       path: '/socket.io',
       transports: ['websocket'],
@@ -32,6 +37,17 @@ export const createSocket = (): Socket | null => {
       reconnectionDelay: 1000,
       reconnectionDelayMax: 5000,
       reconnectionAttempts: 5,
+      auth: {
+        token: accessToken,
+      },
+
+      transportOptions: {
+        websocket: {
+          extraHeaders: {
+            Cookie: `accessToken=${accessToken}`,
+          },
+        },
+      },
     });
 
     socket.on('connect_error', error => {

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -23,7 +23,6 @@ export const createSocket = (): Socket | null => {
 
   try {
     const apiUrl = getSocketUrl();
-    console.log('[Socket] Connecting to', apiUrl);
     const rawToken =
       typeof document !== 'undefined'
         ? document.cookie
@@ -33,6 +32,9 @@ export const createSocket = (): Socket | null => {
             .slice(1)
             .join('=')
         : undefined;
+
+    const cookies = document.cookie.split('; ');
+    console.log(cookies);
     console.log('[Socket] rawToken:', rawToken ? rawToken.substring(0, 10) + '...' : 'none');
     const accessToken = rawToken ? decodeURIComponent(rawToken) : undefined;
     console.log(

--- a/src/app/lib/socket.ts
+++ b/src/app/lib/socket.ts
@@ -23,7 +23,7 @@ export const createSocket = (): Socket | null => {
 
   try {
     const apiUrl = getSocketUrl();
-
+    console.log('[Socket] Connecting to', apiUrl);
     const rawToken =
       typeof document !== 'undefined'
         ? document.cookie
@@ -33,28 +33,27 @@ export const createSocket = (): Socket | null => {
             .slice(1)
             .join('=')
         : undefined;
-
+    console.log('[Socket] rawToken:', rawToken ? rawToken.substring(0, 10) + '...' : 'none');
     const accessToken = rawToken ? decodeURIComponent(rawToken) : undefined;
-
+    console.log(
+      '[Socket] accessToken:',
+      accessToken ? accessToken.substring(0, 10) + '...' : 'none'
+    );
     const socketOptions: Parameters<typeof io>[1] = {
       path: '/socket.io',
-      transports: ['websocket'],
+      transports: ['websocket', 'polling'],
       withCredentials: true,
       reconnection: true,
       reconnectionDelay: 1000,
       reconnectionDelayMax: 5000,
       reconnectionAttempts: 5,
+      auth: {
+        token: accessToken,
+      },
     };
 
     if (accessToken) {
       socketOptions.auth = { token: accessToken };
-      socketOptions.transportOptions = {
-        websocket: {
-          extraHeaders: {
-            Cookie: `accessToken=${accessToken}`,
-          },
-        },
-      };
     }
 
     socket = io(apiUrl, socketOptions);

--- a/src/domain/Auth/LoginModal/LoginModal.tsx
+++ b/src/domain/Auth/LoginModal/LoginModal.tsx
@@ -50,9 +50,9 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
   const loginMutation = useMutation({
     mutationFn: (data: Auth.LoginReq) => authServiceClient.postLogin(data),
     onSuccess: res => {
-      if (res.accessToken) {
-        document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
-      }
+      // if (res.accessToken) {
+      //   document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
+      // }
 
       setUser(res.user);
 
@@ -72,9 +72,9 @@ export default function LoginModal({ onClose, onSignupOpen }: LoginModalProps) {
     mutationFn: (data: { idToken: string }) => authServiceClient.loginWithGoogle(data),
     onSuccess: res => {
       // 프론트엔드 도메인에서 강제로 쿠키를 저장합니다.
-      if (res.accessToken) {
-        document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
-      }
+      // if (res.accessToken) {
+      //   document.cookie = `accessToken=${res.accessToken}; path=/; max-age=86400; secure; samesite=lax`;
+      // }
 
       setUser(res.user);
       toast.success('구글 로그인에 성공했습니다.');


### PR DESCRIPTION
기존 웹소켓 함수에서 토큰 전달하는 로직이 추가되었습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 실시간 연결 인증 페이로드 개선으로 소켓 연결의 신뢰성 및 일관성 향상.

* **변경**
  * 로그인 후 액세스 토큰을 브라우저에 자동 저장하지 않도록 변경되어 세션 지속 방식이 수정됨(로그인 직후 UI 갱신 유지).
  * 외부 이미지 설정을 원격 패턴으로 전환하여 Google 사용자 이미지 로딩 호환성 향상.
  * 불필요한 디버그 로그 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->