### PR TITLE
[feature/128-favorite-category-preference] - 찜 기반 카테고리 성향 API 연동

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -18,6 +18,7 @@ export default async function Page() {
     const user = await authServiceServer.getMe();
     const favoriteMenus = await favoritesServiceServer.getMyFavorites();
     const foodDotIds = await getMyFoodDotsServer();
+    const preference = await favoritesServiceServer.getMyPreference();
 
     return (
       <div className={styles['mypage']}>
@@ -30,7 +31,7 @@ export default async function Page() {
           </div>
 
           <div className={styles['mypage__bottom']}>
-            <MenuSummaryCard />
+            <MenuSummaryCard preference={preference} />
             <AccountSetting />
           </div>
         </main>

--- a/src/app/services/backend/favorites.api.ts
+++ b/src/app/services/backend/favorites.api.ts
@@ -14,6 +14,13 @@ class FavoritesService {
     });
   }
 
+  // 찜 기반 선호도 분석 조회
+  getMyPreference(): Promise<Favorite.PreferenceResult> {
+    return this.fetcher<Favorite.PreferenceResult>('/favorites/preference', {
+      method: 'GET',
+    });
+  }
+
   // 찜 추가
   addFavorite(menuId: string): Promise<{ isFavorite: boolean }> {
     return this.fetcher<{ isFavorite: boolean }>('/favorites/add', {

--- a/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.module.scss
+++ b/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.module.scss
@@ -6,8 +6,9 @@
   height: 100%;
   padding: 18px 20px;
   border: 1.5px solid f.color(gray-300);
-  box-shadow: 2px 2px 0px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.1);
   border-radius: 14px;
+
   @include m.flex-box(flex-start, stretch, column);
 
   &__header {
@@ -31,6 +32,7 @@
     color: f.color(gray-600);
     flex-shrink: 0;
   }
+
   &__list {
     list-style: none;
     @include m.flex-box(flex-start, stretch, column);
@@ -49,26 +51,26 @@
     @include m.flex-box(flex-start, center);
     gap: 6px;
     @include m.text-style('2lg', 500);
-
     color: inherit;
   }
+
   &__item-icon {
     width: 16px;
     height: 16px;
     flex-shrink: 0;
-    color: inherit; /* 아이콘 컬러는 아이템 컬러를 따라감 */
+    color: inherit;
   }
 
   &__value {
     @include m.text-style('lg', 400);
     color: f.color(gray-900);
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
+  // Preference Bar
   &__bar {
-    height: 6px;
+    height: 8px;
     background: f.color(gray-300);
     border-radius: 32px;
     overflow: hidden;
@@ -78,6 +80,24 @@
     height: 100%;
     background: f.color(point-blue);
     border-radius: 32px;
+    transition: width 0.3s ease;
+  }
+
+  &__category-detail {
+    margin-top: 8px;
+  }
+
+  &__category-row {
+    @include m.flex-box(space-between, center);
+    margin-bottom: 6px;
+  }
+
+  &__category-label {
+    @include m.text-style('md', 500);
+  }
+
+  &__category-percent {
+    @include m.text-style('md', 500);
   }
 
   &__empty {
@@ -105,7 +125,6 @@
     color: f.color(gray-600);
   }
 
-  /* pastel variants (배경 + 라벨 컬러만 담당) */
   &__item--category {
     background: rgba(f.color(point-blue), 0.12);
     color: f.color(point-blue);

--- a/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
+++ b/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
@@ -37,9 +37,8 @@ export default function MenuSummaryCard() {
       };
     }
 
-    const percentage = preference.distribution
-      ? Math.max(...Object.values(preference.distribution))
-      : undefined;
+    const values = preference.distribution ? Object.values(preference.distribution) : []; // 분포 값들
+    const percentage = values.length > 0 ? Math.max(...values) : undefined; // 최댓값
 
     return {
       type: 'category',

--- a/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
+++ b/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
@@ -1,9 +1,15 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
 import type { LucideIcon } from 'lucide-react';
 import { ClipboardList, TrendingUp, Layers, Clock, CookingPot, Users } from 'lucide-react';
 
-import { MENU_SUMMARY_MOCK } from './mock';
-import type { MenuSummaryItemType } from './types';
+import { favoritesServiceClient } from '@/app/services/backend/favorites.api';
 
+import { MENU_SUMMARY_MOCK } from './mock';
+import type { MenuSummaryItemType, MenuSummaryItem } from './types';
 import styles from './MenuSummaryCard.module.scss';
 
 const ITEM_ICON_MAP: Record<MenuSummaryItemType, LucideIcon> = {
@@ -14,8 +20,41 @@ const ITEM_ICON_MAP: Record<MenuSummaryItemType, LucideIcon> = {
 };
 
 export default function MenuSummaryCard() {
+  const { data: preference } = useQuery({
+    queryKey: ['my', 'recent-preference'],
+    queryFn: () => favoritesServiceClient.getMyPreference(),
+  });
+
   const { items } = MENU_SUMMARY_MOCK;
-  const isEmpty = items.length === 0;
+
+  // 가장 선호하는 카테고리 항목 생성
+  const categoryItem: MenuSummaryItem = useMemo(() => {
+    if (!preference || preference.status === 'EMPTY') {
+      return {
+        type: 'category',
+        title: '가장 선호하는 카테고리',
+        value: '데이터 없음',
+      };
+    }
+
+    const percentage = preference.distribution
+      ? Math.max(...Object.values(preference.distribution))
+      : undefined;
+
+    return {
+      type: 'category',
+      title: '가장 선호하는 카테고리',
+      value: preference.summary,
+      percentage,
+    };
+  }, [preference]);
+
+  // 목업 + category 교체
+  const displayItems = useMemo(() => {
+    return [categoryItem, ...items.filter(item => item.type !== 'category')];
+  }, [categoryItem, items]);
+
+  const isEmpty = !preference || preference.status === 'EMPTY';
 
   return (
     <section className={styles['menu-summary']} aria-label="최근 메뉴 성향 요약">
@@ -36,17 +75,18 @@ export default function MenuSummaryCard() {
         </div>
       ) : (
         <ul className={styles['menu-summary__list']}>
-          {items.map(item => {
-            const Icon = ITEM_ICON_MAP[item.type];
+          {displayItems.map(item => {
+            const Icon = ITEM_ICON_MAP[item.type] ?? Layers;
             const modifier = styles[`menu-summary__item--${item.type}`];
 
             const percent =
               typeof item.percentage === 'number'
                 ? Math.max(0, Math.min(100, item.percentage))
                 : undefined;
+
             return (
               <li
-                key={item.type}
+                key={`${item.type}-${item.title}`}
                 className={[styles['menu-summary__item'], modifier].filter(Boolean).join(' ')}
               >
                 <div className={styles['menu-summary__item-header']}>
@@ -54,22 +94,63 @@ export default function MenuSummaryCard() {
                   <span>{item.title}</span>
                 </div>
 
-                <p className={styles['menu-summary__value']}>{item.value}</p>
+                {item.type === 'category' ? (
+                  <>
+                    <p className={styles['menu-summary__value']}>{preference?.summary}</p>
 
-                {percent !== undefined && (
-                  <div
-                    className={styles['menu-summary__bar']}
-                    role="progressbar"
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-valuenow={percent}
-                  >
-                    <div
-                      className={styles['menu-summary__bar-fill']}
-                      style={{ width: `${percent}%` }}
-                      aria-hidden="true"
-                    />
-                  </div>
+                    {preference?.status === 'CONFIDENT' && preference.topCategories?.[0] && (
+                      <div className={styles['menu-summary__category-detail']}>
+                        <div className={styles['menu-summary__category-row']}>
+                          <span className={styles['menu-summary__category-label']}>
+                            {preference.topCategories[0]}
+                          </span>
+                          <span className={styles['menu-summary__category-percent']}>
+                            {preference.distribution?.[preference.topCategories[0]] ?? 0}%
+                          </span>
+                        </div>
+
+                        <div
+                          className={styles['menu-summary__bar']}
+                          role="progressbar"
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-valuenow={
+                            preference.distribution?.[preference.topCategories[0]] ?? 0
+                          }
+                        >
+                          <div
+                            className={styles['menu-summary__bar-fill']}
+                            style={{
+                              width: `${
+                                preference.distribution?.[preference.topCategories[0]] ?? 0
+                              }%`,
+                            }}
+                            aria-hidden="true"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <p className={styles['menu-summary__value']}>{item.value}</p>
+
+                    {percent !== undefined && (
+                      <div
+                        className={styles['menu-summary__bar']}
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={percent}
+                      >
+                        <div
+                          className={styles['menu-summary__bar-fill']}
+                          style={{ width: `${percent}%` }}
+                          aria-hidden="true"
+                        />
+                      </div>
+                    )}
+                  </>
                 )}
               </li>
             );

--- a/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
+++ b/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
@@ -20,7 +20,7 @@ const ITEM_ICON_MAP: Record<MenuSummaryItemType, LucideIcon> = {
 };
 
 export default function MenuSummaryCard() {
-  const { data: preference } = useQuery({
+  const { data: preference, isLoading } = useQuery({
     queryKey: ['my', 'recent-preference'],
     queryFn: () => favoritesServiceClient.getMyPreference(),
   });
@@ -64,7 +64,9 @@ export default function MenuSummaryCard() {
         </div>
       </header>
 
-      {isEmpty ? (
+      {isLoading ? (
+        <div className={styles['menu-summary__loading']}>로딩 중...</div>
+      ) : isEmpty ? (
         <div className={styles['menu-summary__empty']} aria-live="polite">
           <ClipboardList className={styles['menu-summary__empty-icon']} aria-hidden="true" />
           <p className={styles['menu-summary__empty-title']}>최근 메뉴 기록이 아직 없어요</p>

--- a/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
+++ b/src/domain/Mypage/MenuSummaryCard/MenuSummaryCard.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useMemo } from 'react';
-
-import { useQuery } from '@tanstack/react-query';
 import type { LucideIcon } from 'lucide-react';
 import { ClipboardList, TrendingUp, Layers, Clock, CookingPot, Users } from 'lucide-react';
 
@@ -19,12 +17,9 @@ const ITEM_ICON_MAP: Record<MenuSummaryItemType, LucideIcon> = {
   style: Users,
 };
 
-export default function MenuSummaryCard() {
-  const { data: preference, isLoading } = useQuery({
-    queryKey: ['my', 'recent-preference'],
-    queryFn: () => favoritesServiceClient.getMyPreference(),
-  });
+type PreferenceResponse = Awaited<ReturnType<typeof favoritesServiceClient.getMyPreference>>;
 
+export default function MenuSummaryCard({ preference }: { preference?: PreferenceResponse }) {
   const { items } = MENU_SUMMARY_MOCK;
 
   // 가장 선호하는 카테고리 항목 생성
@@ -37,8 +32,8 @@ export default function MenuSummaryCard() {
       };
     }
 
-    const values = preference.distribution ? Object.values(preference.distribution) : []; // 분포 값들
-    const percentage = values.length > 0 ? Math.max(...values) : undefined; // 최댓값
+    const values = preference.distribution ? Object.values(preference.distribution) : [];
+    const percentage = values.length > 0 ? Math.max(...(values as number[])) : undefined;
 
     return {
       type: 'category',
@@ -64,9 +59,7 @@ export default function MenuSummaryCard() {
         </div>
       </header>
 
-      {isLoading ? (
-        <div className={styles['menu-summary__loading']}>로딩 중...</div>
-      ) : isEmpty ? (
+      {isEmpty ? (
         <div className={styles['menu-summary__empty']} aria-live="polite">
           <ClipboardList className={styles['menu-summary__empty-icon']} aria-hidden="true" />
           <p className={styles['menu-summary__empty-title']}>최근 메뉴 기록이 아직 없어요</p>

--- a/src/domain/Mypage/MenuSummaryCard/mock.ts
+++ b/src/domain/Mypage/MenuSummaryCard/mock.ts
@@ -2,7 +2,6 @@ import type { MenuSummaryData, MenuSummaryItem } from './types';
 
 export const MENU_SUMMARY_MOCK = {
   items: [
-    { type: 'category', title: '가장 많이 선택한 카테고리', value: '한식 (42%)', percentage: 42 },
     { type: 'mealTier', title: '평균 식사 기준', value: '보통 한 끼 식사를 가장 자주 선택해요.' },
     { type: 'time', title: '선호하는 시간대', value: '주로 저녁 시간대(18:00~20:00)에 식사해요.' },
     { type: 'style', title: '식사 스타일', value: '혼밥 위주의 식사 패턴이에요.' },

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -62,6 +62,13 @@ namespace Favorite {
     _id: string;
     createdAt: string;
   }
+
+  interface PreferenceResult {
+    status: 'CONFIDENT' | 'WEAK' | 'HINT' | 'EMPTY';
+    topCategories: string[];
+    distribution?: Record<string, number>;
+    summary: string;
+  }
 }
 
 namespace Faq {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 찜 데이터를 기반으로 한 **카테고리 성향 분석 기능 추가**
- 마이페이지 메뉴 성향 요약 카드에서  
  기존 목업 데이터 중 **카테고리 항목을 실데이터로 교체**
- 데이터 상태에 따라 UI 분기 처리
  - EMPTY: 데이터 없음 안내
  - HINT / WEAK: 요약 문구만 표시
  - CONFIDENT: 대표 카테고리 + 비율 시각화

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

### 데이터 부족(HINT / WEAK)
<img width="538" height="151" alt="0" src="https://github.com/user-attachments/assets/1a001a7c-4368-4a2b-9c35-cc5573649f65" />


### 데이터 충분(CONFIDENT)
<img width="532" height="188" alt="222" src="https://github.com/user-attachments/assets/83f27251-6337-4637-b32c-bf16e46cdd90" />

## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1. 로그인 후 마이페이지로 이동
2. 찜 데이터가 없는 계정에서 EMPTY 상태 UI 확인
3. 찜 데이터가 일부 있는 계정에서 요약 문구 표시 확인
4. 찜 데이터가 충분한 계정에서
   - 대표 카테고리
   - 퍼센트 표시
   - 프로그레스 바 렌더링 확인

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#128 
## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
- 찜 데이터는 사용자의 명확한 선호를 반영하는 지표로 판단하여 성향 분석 기준 데이터로 사용했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메뉴 요약 카드에 사용자 선호 요약 반영: 선호 상태에 따른 상위 카테고리, 퍼센트 표시 및 신뢰도 기반 상세 행과 진행률 바 노출; 비어 있을 땐 대체 문구 제공
  * 페이지에서 사용자 선호를 가져와 카드에 전달

* **스타일**
  * 카드 그림자 단순화 및 진행률 막대 높이 증가
  * 카테고리 상세 섹션 추가 및 막대 채우기 너비 전환 애니메이션 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->