### PR TITLE
[fix/132-roulette-filter] - 웹소켓 필터 동기화 무한 루프 수정

### DIFF
--- a/src/domain/Roulette/Roulette.tsx
+++ b/src/domain/Roulette/Roulette.tsx
@@ -59,7 +59,10 @@ export const Roulette = memo(function Roulette({
     if (!socket) return;
 
     // 연결 성공 시 사용자 ID 저장
-    const handleConnected = ({ user }: { user: { _id?: string; id?: string } }) => {
+    const handleConnected = (payload?: { user?: { _id?: string; id?: string } }) => {
+      if (!payload?.user) return;
+
+      const { user } = payload;
       const userId = user.id || user._id;
       if (userId) {
         setCurrentUserId(userId);

--- a/src/domain/Roulette/Roulette.tsx
+++ b/src/domain/Roulette/Roulette.tsx
@@ -30,12 +30,15 @@ export const Roulette = memo(function Roulette({
     context?: Context[];
   }>({});
   const [localResult, setLocalResult] = useState<Menu.GetMenuRes | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
   // 게스트용 동기화된 필터 상태
   const [syncedFilterState, setSyncedFilterState] = useState<{
     mode: 'category' | 'context';
     selectedFoodTypes: Category | null;
     selectedSituation: Context | null;
+    timestamp?: number;
+    updatedBy?: string;
   } | null>(null);
 
   const params = useParams();
@@ -49,20 +52,40 @@ export const Roulette = memo(function Roulette({
     }
   }, [initialMenus]);
 
-  // ============ WebSocket 이벤트 리스너 ============
   useEffect(() => {
     if (isSoloMode) return;
 
     const socket = getSocket();
     if (!socket) return;
 
-    // 메뉴 동기화 이벤트 (서버에서 직접 메뉴 목록 받음)
+    // 연결 성공 시 사용자 ID 저장
+    const handleConnected = ({ user }: { user: { _id?: string; id?: string } }) => {
+      const userId = user.id || user._id;
+      if (userId) {
+        setCurrentUserId(userId);
+      }
+    };
+
     const handleMenusSync = ({ menus }: { menus: Menu.GetMenuRes[] }) => {
       setMenus(menus);
     };
 
-    // 역할 할당 이벤트 - 초기 메뉴 설정
-    const handleRoleAssigned = ({ menus }: { role: string; menus: Menu.GetMenuRes[] }) => {
+    // 역할 할당 이벤트 (호스트/게스트 역할 부여)
+    const handleRoleAssigned = ({
+      menus,
+      user,
+    }: {
+      role: string;
+      menus: Menu.GetMenuRes[];
+      user?: { _id?: string; id?: string };
+    }) => {
+      // 사용자 ID 저장
+      if (user) {
+        const userId = user.id || user._id;
+        if (userId) {
+          setCurrentUserId(userId);
+        }
+      }
       if (menus && menus.length > 0) {
         setMenus(menus);
       }
@@ -74,6 +97,8 @@ export const Roulette = memo(function Roulette({
       mode,
       selectedFoodTypes,
       selectedSituation,
+      updatedBy,
+      timestamp,
       menus,
     }: {
       filters: { category?: Category[]; context?: Context[] };
@@ -81,25 +106,33 @@ export const Roulette = memo(function Roulette({
       selectedFoodTypes: Category | null;
       selectedSituation: Context | null;
       updatedBy: string;
+      timestamp?: number;
       menus: Menu.GetMenuRes[];
     }) => {
       setFilters(filters);
-      setSyncedFilterState({ mode, selectedFoodTypes, selectedSituation });
-      setMenus(menus); // 호스트도 서버에서 받은 메뉴 목록 사용
+      setSyncedFilterState({
+        mode,
+        selectedFoodTypes,
+        selectedSituation,
+        timestamp,
+        updatedBy,
+      });
+      setMenus(menus);
     };
 
+    socket.on('connected', handleConnected);
     socket.on('menusSync', handleMenusSync);
     socket.on('roleAssigned', handleRoleAssigned);
     socket.on('rouletteFiltersUpdated', handleFiltersUpdated);
 
     return () => {
+      socket.off('connected', handleConnected);
       socket.off('menusSync', handleMenusSync);
       socket.off('roleAssigned', handleRoleAssigned);
       socket.off('rouletteFiltersUpdated', handleFiltersUpdated);
     };
   }, [isSoloMode]);
 
-  // ============ 필터 변경 ============
   const handleFiltersChange = useCallback(
     (
       newFilters: { category?: Category[]; context?: Context[] },
@@ -108,7 +141,7 @@ export const Roulette = memo(function Roulette({
       selectedSituation: Context | null
     ) => {
       setFilters(newFilters);
-      // 서버에서 받은 menus 배열을 그대로 사용 (섞거나 정렬하지 않음)
+      // 호스트가 필터를 변경할 때만 소켓으로 전송
       if (!isSoloMode && userRole === 'host') {
         const socket = getSocket();
         if (socket) {
@@ -125,7 +158,6 @@ export const Roulette = memo(function Roulette({
     [roomCode, isSoloMode, userRole]
   );
 
-  // ============ 룰렛 결과 ============
   const handleResult = useCallback(
     (item: Menu.GetMenuRes) => {
       setLocalResult(item);
@@ -136,7 +168,6 @@ export const Roulette = memo(function Roulette({
     [onSpinResult]
   );
 
-  // ============ 스핀 시작 시 결과 초기화 ============
   const handleSpinStart = useCallback(() => {
     setLocalResult(null);
     setModalOpen(false);
@@ -145,7 +176,6 @@ export const Roulette = memo(function Roulette({
     setSpinning(true);
   }, [onSpinStart, onSpinResult]);
 
-  // ============ 모달 제어 ============
   const handleCloseModal = useCallback(() => {
     setModalOpen(false);
   }, []);
@@ -186,6 +216,7 @@ export const Roulette = memo(function Roulette({
           onFiltersChange={userRole === 'host' || isSoloMode ? handleFiltersChange : undefined}
           disabled={(userRole !== 'host' && !isSoloMode) || spinning || isSpinning}
           syncedFilterState={syncedFilterState}
+          currentUserId={currentUserId}
           isVisible={true}
         />
       )}

--- a/src/domain/Roulette/components/RouletteFilter/RouletteFilter.tsx
+++ b/src/domain/Roulette/components/RouletteFilter/RouletteFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 
 import Button from '@/shared/components/Button';
@@ -24,7 +24,10 @@ interface RouletteFilterProps {
     mode: 'category' | 'context';
     selectedFoodTypes: Category | null;
     selectedSituation: Context | null;
+    timestamp?: number;
+    updatedBy?: string;
   } | null;
+  currentUserId?: string | null;
   isVisible?: boolean;
 }
 
@@ -33,41 +36,47 @@ export default function RouletteFilter({
   onFiltersChange,
   disabled = false,
   syncedFilterState = null,
+  currentUserId = null,
   isVisible = true,
 }: RouletteFilterProps) {
-  const {
-    state: { mode, selectedFoodTypes, selectedSituation, menus },
-    actions: { changeMode, toggleFoodType, toggleSituation },
-  } = useRouletteFilter(syncedFilterState);
-
-  const { foodOptions, situationOptions } = useFilterOptions(selectedFoodTypes, selectedSituation);
-
   const params = useParams();
   const roomCode = (params?.roomId as string) || 'solo';
   const isSoloMode = roomCode === 'solo';
 
-  // ============ 메뉴 변경 감지 ============
+  // 사용자 액션 시 즉시 소켓으로 필터 변경 전송
+  const handleUserAction = useCallback(
+    (newMode: 'category' | 'context', newFood: Category | null, newSituation: Context | null) => {
+      // 솔로 모드에서는 소켓 전송 안 함
+      if (isSoloMode) return;
+
+      // 같이정하기 모드에서만 소켓으로 필터 변경 전송
+      onFiltersChange?.(
+        {
+          category: newFood && newFood !== Category.ALL ? [newFood] : undefined,
+          context: newSituation ? [newSituation] : undefined,
+        },
+        newMode,
+        newFood,
+        newSituation
+      );
+    },
+    [isSoloMode, onFiltersChange]
+  );
+
+  // 같이 정하기 모드에서 동기화된 필터 상태 사용
+  const {
+    state: { mode, selectedFoodTypes, selectedSituation, menus },
+    actions: { changeMode, toggleFoodType, toggleSituation },
+  } = useRouletteFilter(syncedFilterState, currentUserId ?? undefined, handleUserAction);
+
+  const { foodOptions, situationOptions } = useFilterOptions(selectedFoodTypes, selectedSituation);
+
   useEffect(() => {
     if (!menus || menus.length === 0) return;
     if (isSoloMode) {
       onChange(menus);
     }
   }, [menus, onChange, isSoloMode, roomCode]);
-
-  // ============ 필터 변경 감지 ============
-  useEffect(() => {
-    if (isSoloMode) return;
-
-    onFiltersChange?.(
-      {
-        category: selectedFoodTypes ? [selectedFoodTypes] : undefined,
-        context: selectedSituation ? [selectedSituation] : undefined,
-      },
-      mode,
-      selectedFoodTypes,
-      selectedSituation
-    );
-  }, [selectedFoodTypes, selectedSituation, mode, isSoloMode, onFiltersChange]);
 
   const modeClass = (isActive: boolean) =>
     `${styles['filter__mode__tab']} ${isActive ? styles['filter__mode__tab--active'] : ''}`;

--- a/src/domain/Roulette/hooks/useRouletteFilter.ts
+++ b/src/domain/Roulette/hooks/useRouletteFilter.ts
@@ -70,19 +70,21 @@ export function useRouletteFilter(
   const { data: fetchedMenus = [], isLoading } = useQuery({
     queryKey: ['roulette-menus', roomId, mode, activeFilter],
     queryFn: async () => {
-      if (mode === 'category') {
-        if (selectedFoodTypes && selectedFoodTypes !== Category.ALL) {
+      try {
+        if (mode === 'category' && selectedFoodTypes && selectedFoodTypes !== Category.ALL) {
           const result = await rouletteApi.getMenusByCategory(selectedFoodTypes, roomId);
           return result.slice(0, 6);
-        } else {
+        } else if (mode === 'category') {
           const result = await rouletteApi.getAllMenus(roomId);
           return result.slice(0, 6);
+        } else if (mode === 'context' && selectedSituation) {
+          const result = await rouletteApi.getMenusByContext(selectedSituation, roomId);
+          return result.slice(0, 6);
         }
-      } else if (mode === 'context' && selectedSituation) {
-        const result = await rouletteApi.getMenusByContext(selectedSituation, roomId);
-        return result.slice(0, 6);
+        return [];
+      } catch {
+        return [];
       }
-      return [];
     },
     staleTime: 5 * 60 * 1000,
     enabled: !!roomId,

--- a/src/domain/Roulette/hooks/useRouletteFilter.ts
+++ b/src/domain/Roulette/hooks/useRouletteFilter.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 
@@ -26,8 +26,15 @@ export function useRouletteFilter(
     mode: FilterMode;
     selectedFoodTypes: Category | null;
     selectedSituation: Context | null;
-  } | null
+    timestamp?: number;
+    updatedBy?: string;
+  } | null,
+  currentUserId?: string,
+
+  // 사용자 클릭 시 즉시 emit을 발생시킬 콜백
+  onUserAction?: (mode: FilterMode, foodType: Category | null, situation: Context | null) => void
 ): { state: State; actions: Actions } {
+  const lastLocalUpdateRef = useRef<number>(0);
   const [mode, setMode] = useState<FilterMode>(syncedState?.mode || 'category');
   const [selectedFoodTypes, setSelectedFoodTypes] = useState<Category>(
     syncedState?.selectedFoodTypes || Category.ALL
@@ -39,66 +46,105 @@ export function useRouletteFilter(
   const params = useParams();
   const roomId = (params?.roomId as string) || 'solo';
 
-  // 동기화된 상태가 있으면 업데이트
   useEffect(() => {
-    if (syncedState) {
-      setMode(syncedState.mode);
-      setSelectedFoodTypes(syncedState.selectedFoodTypes || Category.ALL);
-      setSelectedSituation(syncedState.selectedSituation);
+    if (!syncedState) return;
+
+    // 자기 에코 방지
+    if (currentUserId && syncedState.updatedBy === currentUserId) {
+      return;
     }
-  }, [syncedState]);
+
+    // 타임스탬프 비교로 최신 상태인지 확인
+    if (syncedState.timestamp && syncedState.timestamp < lastLocalUpdateRef.current) {
+      return;
+    }
+
+    // 서버에서 받은 상태로 동기화
+    setMode(syncedState.mode);
+    setSelectedFoodTypes(syncedState.selectedFoodTypes || Category.ALL);
+    setSelectedSituation(syncedState.selectedSituation);
+  }, [syncedState, currentUserId]);
 
   const activeFilter = mode === 'category' ? selectedFoodTypes : selectedSituation;
 
-  // 필터에 맞는 메뉴 조회
   const { data: fetchedMenus = [], isLoading } = useQuery({
     queryKey: ['roulette-menus', roomId, mode, activeFilter],
     queryFn: async () => {
-      try {
-        if (mode === 'category' && selectedFoodTypes && selectedFoodTypes !== Category.ALL) {
+      if (mode === 'category') {
+        if (selectedFoodTypes && selectedFoodTypes !== Category.ALL) {
           const result = await rouletteApi.getMenusByCategory(selectedFoodTypes, roomId);
           return result.slice(0, 6);
-        } else if (mode === 'category' && selectedFoodTypes === Category.ALL) {
+        } else {
           const result = await rouletteApi.getAllMenus(roomId);
           return result.slice(0, 6);
-        } else if (mode === 'context' && selectedSituation) {
-          const result = await rouletteApi.getMenusByContext(selectedSituation, roomId);
-          return result.slice(0, 6);
         }
-        return [];
-      } catch (error) {
-        throw error;
+      } else if (mode === 'context' && selectedSituation) {
+        const result = await rouletteApi.getMenusByContext(selectedSituation, roomId);
+        return result.slice(0, 6);
       }
+      return [];
     },
-    staleTime: 5 * 60 * 1000, // 5분
+    staleTime: 5 * 60 * 1000,
     enabled: !!roomId,
     retry: 1,
   });
 
-  const changeMode = useCallback((newMode: FilterMode) => {
-    setMode(newMode);
-  }, []);
+  const changeMode = useCallback(
+    (newMode: FilterMode) => {
+      lastLocalUpdateRef.current = Date.now();
+      setMode(newMode);
 
-  const toggleFoodType = useCallback((category: Category) => {
-    setSelectedFoodTypes(prev => (prev === category ? Category.ALL : category));
-  }, []);
+      let nextFood = selectedFoodTypes;
+      let nextSit = selectedSituation;
 
-  const toggleSituation = useCallback((context: Context) => {
-    setSelectedSituation(prev => (prev === context ? null : context));
-  }, []);
+      if (newMode === 'context') {
+        nextFood = Category.ALL;
+        setSelectedFoodTypes(Category.ALL);
+      } else {
+        nextSit = null;
+        setSelectedSituation(null);
+      }
+
+      // 상태 변경 후 서버로 전송
+      onUserAction?.(newMode, nextFood, nextSit);
+    },
+    [selectedFoodTypes, selectedSituation, onUserAction]
+  );
+
+  const toggleFoodType = useCallback(
+    (category: Category) => {
+      lastLocalUpdateRef.current = Date.now();
+      setMode('category');
+      setSelectedSituation(null);
+
+      // 다음 상태를 미리 계산
+      const nextVal = selectedFoodTypes === category ? Category.ALL : category;
+      setSelectedFoodTypes(nextVal);
+
+      // 상태 변경 후 서버로 전송
+      onUserAction?.('category', nextVal, null);
+    },
+    [selectedFoodTypes, onUserAction]
+  );
+
+  const toggleSituation = useCallback(
+    (context: Context) => {
+      lastLocalUpdateRef.current = Date.now();
+      setMode('context');
+      setSelectedFoodTypes(Category.ALL);
+
+      // 다음 상태를 미리 계산
+      const nextVal = selectedSituation === context ? null : context;
+      setSelectedSituation(nextVal);
+
+      // 상태 변경 후 서버로 전송
+      onUserAction?.('context', Category.ALL, nextVal);
+    },
+    [selectedSituation, onUserAction]
+  );
 
   return {
-    state: {
-      mode,
-      selectedFoodTypes,
-      selectedSituation,
-      menus: fetchedMenus,
-      isLoading,
-    },
-    actions: {
-      changeMode,
-      toggleFoodType,
-      toggleSituation,
-    },
+    state: { mode, selectedFoodTypes, selectedSituation, menus: fetchedMenus, isLoading },
+    actions: { changeMode, toggleFoodType, toggleSituation },
   };
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- ```useEffect```를 이용한 수동적 상태 감지 방식에서 사용자 클릭 시점에만 소켓을 전송하는 방식으로 변경하여 무한 루프를 원천 차단
- 서버에서 브로드캐스트된 데이터 중 본인이 발생시킨 이벤트```(updatedBy)```를 식별하여 중복 업데이트를 방지
- ```chat.gateway.ts```에서 발신자 정보와 타임스탬프를 포함하도록 데이터 구조를 개선하고, 방 퇴장 시 호스트 위임 및 상태 정리 로직을 안정화
## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1. 방에 호스트와 게스트로 동시 접속합니다.
2. 호스트가 필터 버튼을 빠르게 클릭합니다.
3. 네트워크 탭에서 무한 루프 발생 여부를 확인하고, 게스트 화면에 필터가 정상 동기화되는지 검증합니다.
4. 호스트가 방을 나갔을 때 시스템 메시지 출력 및 권한 위임이 정상적으로 이루어지는지 확인합니다.


## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#132 
## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 현재 접속 사용자 식별 정보 전달로 사용자가 누가 변경했는지 추적 가능
  * 비솔로 모드에서 사용자가 직접 수행한 필터 변경만 동기화하도록 사용자-주도 동작 경로 도입

* **개선 사항**
  * 동기화 상태에 타임스탬프·업데이터 정보를 포함해 동시 갱신 충돌 방지 향상
  * 자기 변경에 대한 반영(에코) 억제로 멀티플레이어 동기화 안정성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->