### PR TITLE
[refactor/161-main-render-structure] - 메인 페이지 렌더링 구조 정리 및 hydration 오류 해결

### DIFF
--- a/src/app/MainClient.tsx
+++ b/src/app/MainClient.tsx
@@ -8,6 +8,8 @@ import WeatherMood from '@/features/WeatherMood/WeatherMood';
 import RoomEntryCard from '@/features/Room/RoomEntryCard/RoomEntryCard';
 import QuoteCard from '@/features/QuoteCard';
 import { menusServiceClient } from '@/services/backend/menus.api';
+import type { TopFavoriteMenu } from '@/services/backend/menus.api';
+import type { WeatherApiResponse } from '@/features/WeatherMood/hooks/useWeather';
 import { mapTopFavoritesToCarousel } from '@/shared/utils/mapTopFavoritesToCarousel';
 
 import styles from './page.module.scss';
@@ -37,7 +39,17 @@ const FALLBACK_ITEMS: CarouselItem[] = [
   },
 ];
 
-export default function MainClient() {
+interface MainClientProps {
+  initialTopMenus: TopFavoriteMenu[];
+  initialCarouselItems: CarouselItem[];
+  initialWeatherData: WeatherApiResponse | null;
+}
+
+export default function MainClient({
+  initialTopMenus,
+  initialCarouselItems,
+  initialWeatherData,
+}: MainClientProps) {
   const {
     data: topMenus,
     isLoading,
@@ -45,13 +57,16 @@ export default function MainClient() {
   } = useQuery({
     queryKey: ['menus', 'favorites', 'top'],
     queryFn: () => menusServiceClient.getTopFavoriteMenus(3),
+    initialData: initialTopMenus,
     staleTime: 30_000,
   });
 
   const carouselItems: CarouselItem[] =
     !isLoading && !isError && topMenus?.length
       ? mapTopFavoritesToCarousel(topMenus)
-      : FALLBACK_ITEMS;
+      : initialCarouselItems.length
+        ? initialCarouselItems
+        : FALLBACK_ITEMS;
 
   return (
     <div className={styles['container']}>
@@ -64,7 +79,7 @@ export default function MainClient() {
       <section className={styles['container__right']}>
         <h2 className="sr-only">현재 정보</h2>
         <Clock />
-        <WeatherMood />
+        <WeatherMood initialWeatherData={initialWeatherData} />
         <QuoteCard />
       </section>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import type { CarouselItem } from '@/shared/components/Carousel';
-import { menusServiceServer, type TopFavoriteMenu } from '@/services/backend/menus.api';
+import { menusServiceServer } from '@/services/backend/menus.api';
 import { mapTopFavoritesToCarousel } from '@/shared/utils/mapTopFavoritesToCarousel';
 import { fetchAirPollution, fetchWeather } from '@/services/weather/openWeather';
 import { normalizeAir, normalizeWeather } from '@/services/weather/normalizeWeather';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,38 +31,28 @@ export const metadata: Metadata = {
 const SEOUL_LAT = 37.5665;
 const SEOUL_LON = 126.978;
 
-const FALLBACK_ITEMS: CarouselItem[] = [
-  {
-    id: 'fallback-1',
-    menuName: '추천 메뉴 준비중',
-    rank: 1,
-    favoriteCount: 0,
-    stores: [],
-  },
-  {
-    id: 'fallback-2',
-    menuName: '추천 메뉴 준비중',
-    rank: 2,
-    favoriteCount: 0,
-    stores: [],
-  },
-  {
-    id: 'fallback-3',
-    menuName: '추천 메뉴 준비중',
-    rank: 3,
-    favoriteCount: 0,
-    stores: [],
-  },
-];
+const FALLBACK_ITEMS: CarouselItem[] = Array.from({ length: 3 }, (_, i) => ({
+  id: `fallback-${i + 1}`,
+  menuName: '추천 메뉴 준비중',
+  rank: i + 1,
+  favoriteCount: 0,
+  stores: [],
+}));
 
 export default async function HomePage() {
   const revalidateSeconds = secondsUntilNextKstBoundary();
 
-  const [topMenus, weatherRaw, airRaw] = await Promise.all([
-    menusServiceServer.getTopFavoriteMenus(3).catch(() => [] as TopFavoriteMenu[]),
-    fetchWeather(SEOUL_LAT, SEOUL_LON, revalidateSeconds).catch(() => null),
-    fetchAirPollution(SEOUL_LAT, SEOUL_LON, revalidateSeconds).catch(() => undefined),
+  const [topMenusResult, weatherResult, airResult] = await Promise.allSettled([
+    menusServiceServer.getTopFavoriteMenus(3),
+    fetchWeather(SEOUL_LAT, SEOUL_LON, revalidateSeconds),
+    fetchAirPollution(SEOUL_LAT, SEOUL_LON, revalidateSeconds),
   ]);
+
+  const topMenus = topMenusResult.status === 'fulfilled' ? topMenusResult.value : [];
+
+  const weatherRaw = weatherResult.status === 'fulfilled' ? weatherResult.value : null;
+
+  const airRaw = airResult.status === 'fulfilled' ? airResult.value : undefined;
 
   const initialCarouselItems = topMenus.length
     ? mapTopFavoritesToCarousel(topMenus)
@@ -71,7 +61,7 @@ export default async function HomePage() {
   const initialWeatherData: WeatherApiResponse | null = weatherRaw
     ? {
         weather: normalizeWeather(weatherRaw),
-        air: normalizeAir(airRaw),
+        air: airRaw ? normalizeAir(airRaw) : null,
       }
     : null;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,11 @@
 import type { Metadata } from 'next';
+import type { CarouselItem } from '@/shared/components/Carousel';
+import { menusServiceServer, type TopFavoriteMenu } from '@/services/backend/menus.api';
+import { mapTopFavoritesToCarousel } from '@/shared/utils/mapTopFavoritesToCarousel';
+import { fetchAirPollution, fetchWeather } from '@/services/weather/openWeather';
+import { normalizeAir, normalizeWeather } from '@/services/weather/normalizeWeather';
+import { secondsUntilNextKstBoundary } from '@/services/weather/timeSlotCache';
+import type { WeatherApiResponse } from '@/features/WeatherMood/hooks/useWeather';
 
 import MainClient from './MainClient';
 
@@ -21,6 +28,58 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HomePage() {
-  return <MainClient />;
+const SEOUL_LAT = 37.5665;
+const SEOUL_LON = 126.978;
+
+const FALLBACK_ITEMS: CarouselItem[] = [
+  {
+    id: 'fallback-1',
+    menuName: '추천 메뉴 준비중',
+    rank: 1,
+    favoriteCount: 0,
+    stores: [],
+  },
+  {
+    id: 'fallback-2',
+    menuName: '추천 메뉴 준비중',
+    rank: 2,
+    favoriteCount: 0,
+    stores: [],
+  },
+  {
+    id: 'fallback-3',
+    menuName: '추천 메뉴 준비중',
+    rank: 3,
+    favoriteCount: 0,
+    stores: [],
+  },
+];
+
+export default async function HomePage() {
+  const revalidateSeconds = secondsUntilNextKstBoundary();
+
+  const [topMenus, weatherRaw, airRaw] = await Promise.all([
+    menusServiceServer.getTopFavoriteMenus(3).catch(() => [] as TopFavoriteMenu[]),
+    fetchWeather(SEOUL_LAT, SEOUL_LON, revalidateSeconds).catch(() => null),
+    fetchAirPollution(SEOUL_LAT, SEOUL_LON, revalidateSeconds).catch(() => undefined),
+  ]);
+
+  const initialCarouselItems = topMenus.length
+    ? mapTopFavoritesToCarousel(topMenus)
+    : FALLBACK_ITEMS;
+
+  const initialWeatherData: WeatherApiResponse | null = weatherRaw
+    ? {
+        weather: normalizeWeather(weatherRaw),
+        air: normalizeAir(airRaw),
+      }
+    : null;
+
+  return (
+    <MainClient
+      initialTopMenus={topMenus}
+      initialCarouselItems={initialCarouselItems}
+      initialWeatherData={initialWeatherData}
+    />
+  );
 }

--- a/src/features/QuoteCard/QuoteCard.tsx
+++ b/src/features/QuoteCard/QuoteCard.tsx
@@ -23,7 +23,13 @@ export default function QuoteCard() {
     setQuote(QUOTES[index]);
   }, []);
 
-  if (!quote) return null;
+  if (!quote) {
+    return (
+      <section className={styles['quote-card']} aria-label="메시지 카드">
+        <p className={styles['quote-card__text']}>메시지를 준비하는 중이에요 😊</p>
+      </section>
+    );
+  }
 
   const sentences = quote.split('\n');
 

--- a/src/features/WeatherMood/WeatherMood.tsx
+++ b/src/features/WeatherMood/WeatherMood.tsx
@@ -7,6 +7,7 @@ import TopTabs from '@/shared/components/TopTabs';
 
 import MoodRecommend from './components/Mood/MoodRecommend';
 import WeatherRecommend from './components/Weather/WeatherRecommend';
+import type { WeatherApiResponse } from './hooks/useWeather';
 
 import type { TopTabItem } from '@/shared/components/TopTabs';
 
@@ -21,7 +22,11 @@ const DEFAULT_TAB: TabValue = TAB_LIST[0].value;
 const isTabValue = (value: string): value is TabValue =>
   TAB_LIST.some(item => item.value === value);
 
-export default function WeatherMood() {
+interface WeatherMoodProps {
+  initialWeatherData?: WeatherApiResponse | null;
+}
+
+export default function WeatherMood({ initialWeatherData = null }: WeatherMoodProps) {
   const [activeTab, setActiveTab] = useState<TabValue>(DEFAULT_TAB);
 
   return (
@@ -32,7 +37,9 @@ export default function WeatherMood() {
         if (isTabValue(next)) setActiveTab(next);
       }}
       renderPanel={active => {
-        if (active === 'weather') return <WeatherRecommend />;
+        if (active === 'weather') {
+          return <WeatherRecommend initialWeatherData={initialWeatherData} />;
+        }
         return <MoodRecommend />;
       }}
     />

--- a/src/features/WeatherMood/components/Weather/WeatherRecommend.module.scss
+++ b/src/features/WeatherMood/components/Weather/WeatherRecommend.module.scss
@@ -134,6 +134,7 @@
 .weather-skeleton {
   &__icon {
     @extend %skeleton;
+
     width: 72px;
     height: 72px;
     border-radius: 999px;
@@ -141,6 +142,7 @@
 
   &__temp {
     @extend %skeleton;
+
     width: 48px;
     height: 24px;
     margin-left: 8px;
@@ -148,6 +150,7 @@
 
   &__text {
     @extend %skeleton;
+
     height: 16px;
     width: 60%;
     margin-bottom: 8px;
@@ -159,6 +162,7 @@
 
   &__menu {
     @extend %skeleton;
+
     height: 36px;
     width: 100%;
   }

--- a/src/features/WeatherMood/components/Weather/WeatherRecommend.module.scss
+++ b/src/features/WeatherMood/components/Weather/WeatherRecommend.module.scss
@@ -1,6 +1,7 @@
 @use 'utils/mixins' as m;
 @use 'utils/functions' as f;
 @use 'utils/variables' as v;
+@use 'utils/skeleton';
 
 .weather-recommend {
   width: 100%;
@@ -26,7 +27,7 @@
     flex-wrap: wrap;
     padding: 16px;
     margin-bottom: 20px;
-    background: var(--surface);
+    background: var(--surface-2);
     border: 1px solid var(--border);
     box-shadow: var(--shadow);
     border-radius: 14px;
@@ -127,6 +128,39 @@
       transform: translateY(-2px);
       cursor: pointer;
     }
+  }
+}
+
+.weather-skeleton {
+  &__icon {
+    @extend %skeleton;
+    width: 72px;
+    height: 72px;
+    border-radius: 999px;
+  }
+
+  &__temp {
+    @extend %skeleton;
+    width: 48px;
+    height: 24px;
+    margin-left: 8px;
+  }
+
+  &__text {
+    @extend %skeleton;
+    height: 16px;
+    width: 60%;
+    margin-bottom: 8px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__menu {
+    @extend %skeleton;
+    height: 36px;
+    width: 100%;
   }
 }
 

--- a/src/features/WeatherMood/components/Weather/WeatherRecommend.tsx
+++ b/src/features/WeatherMood/components/Weather/WeatherRecommend.tsx
@@ -5,12 +5,14 @@ import { useState } from 'react';
 import { Wind, Droplet } from 'lucide-react';
 
 import { useWeather } from '@/features/WeatherMood/hooks/useWeather';
+import type { WeatherApiResponse } from '@/features/WeatherMood/hooks/useWeather';
 import { useWeatherRecommend } from '@/features/WeatherMood/hooks/useWeatherRecommend';
 import { getShortDescription } from '@/features/WeatherMood/components/Weather/utils/shortWeather';
 import { getCategoryByMenu } from '@/features/WeatherMood/utils/getCategoryByMenu';
 import { getFoodImageByMenu } from '@/shared/utils/getFoodImageByMenu';
 import { preloadFoodImages } from '@/features/WeatherMood/utils/preloadFoodImages';
 import MenuModal from '@/features/WeatherMood/components/MenuModal/MenuModal';
+import WeatherRecommendSkeleton from './WeatherRecommendSkeleton';
 
 import styles from './WeatherRecommend.module.scss';
 
@@ -32,8 +34,12 @@ function getAqiLabel(aqi: number) {
   }
 }
 
-export default function WeatherRecommend() {
-  const { weather, air, error, loading } = useWeather();
+interface WeatherRecommendProps {
+  initialWeatherData?: WeatherApiResponse | null;
+}
+
+export default function WeatherRecommend({ initialWeatherData = null }: WeatherRecommendProps) {
+  const { weather, air, error, loading } = useWeather({ initialData: initialWeatherData });
   const currentWeather = weather?.weather?.[0] ?? null;
   const mainWeather = currentWeather?.main ?? null;
   const feelsLike = weather ? Math.round(weather.main.feels_like) : null;
@@ -42,7 +48,7 @@ export default function WeatherRecommend() {
   const [selectedMenu, setSelectedMenu] = useState<string | null>(null);
 
   if (loading || recommendLoading) {
-    return <p className={styles['weather-recommend__text']}>날씨 불러오는 중...</p>;
+    return <WeatherRecommendSkeleton />;
   }
 
   if (error) {
@@ -50,7 +56,7 @@ export default function WeatherRecommend() {
   }
 
   if (!weather || !currentWeather || !menus) {
-    return null;
+    return <WeatherRecommendSkeleton />;
   }
 
   const description = getShortDescription(currentWeather.description ?? '');

--- a/src/features/WeatherMood/components/Weather/WeatherRecommendSkeleton.tsx
+++ b/src/features/WeatherMood/components/Weather/WeatherRecommendSkeleton.tsx
@@ -1,0 +1,27 @@
+import styles from './WeatherRecommend.module.scss';
+
+export default function WeatherRecommendSkeleton() {
+  return (
+    <div className={styles['weather-recommend']} aria-hidden>
+      <div className={styles['weather-recommend__card']}>
+        <div className={styles['weather-recommend__icon-wrap']}>
+          <div className={styles['weather-skeleton__icon']} />
+          <div className={styles['weather-skeleton__temp']} />
+        </div>
+
+        <div className={styles['weather-recommend__content']}>
+          <div className={styles['weather-skeleton__text']} />
+          <div className={styles['weather-skeleton__text']} />
+        </div>
+      </div>
+
+      <div className={styles['weather-skeleton__text']} />
+
+      <div className={styles['weather-recommend__list']}>
+        {Array.from({ length: 6 }).map((_, idx) => (
+          <div key={idx} className={styles['weather-skeleton__menu']} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/WeatherMood/hooks/useWeather.ts
+++ b/src/features/WeatherMood/hooks/useWeather.ts
@@ -6,7 +6,7 @@ import type { WeatherData } from '@/types/api/weather';
 // API 응답 타입(날씨 + 대기)
 export interface WeatherApiResponse {
   weather: WeatherData;
-  air: NormalizedAirPollutionData;
+  air: NormalizedAirPollutionData | null;
 }
 
 interface UseWeatherOptions {

--- a/src/features/WeatherMood/hooks/useWeather.ts
+++ b/src/features/WeatherMood/hooks/useWeather.ts
@@ -4,9 +4,13 @@ import type { NormalizedAirPollutionData } from '@/types/api/airPollution';
 import type { WeatherData } from '@/types/api/weather';
 
 // API 응답 타입(날씨 + 대기)
-interface WeatherApiResponse {
+export interface WeatherApiResponse {
   weather: WeatherData;
   air: NormalizedAirPollutionData;
+}
+
+interface UseWeatherOptions {
+  initialData?: WeatherApiResponse | null;
 }
 
 // useWeather 훅이 외부로 반환하는 상태 타입
@@ -81,12 +85,14 @@ function buildWeatherApiUrl(params?: { lat: number; lon: number }): string {
   return queryString ? `/api/weather?${queryString}` : '/api/weather';
 }
 
-export function useWeather() {
+export function useWeather(options: UseWeatherOptions = {}) {
+  const { initialData = null } = options;
+
   const [state, setState] = useState<WeatherState>({
-    weather: null,
-    air: null,
+    weather: initialData?.weather ?? null,
+    air: initialData?.air ?? null,
     error: null,
-    loading: true,
+    loading: !initialData,
     usedUserLocation: false,
   });
 
@@ -110,6 +116,17 @@ export function useWeather() {
   }, []);
 
   useEffect(() => {
+    if (initialData) {
+      setState({
+        weather: initialData.weather,
+        air: initialData.air,
+        error: null,
+        loading: false,
+        usedUserLocation: false,
+      });
+      return;
+    }
+
     requestSequenceRef.current += 1;
     const currentRequestId = requestSequenceRef.current;
 
@@ -192,7 +209,7 @@ export function useWeather() {
     }
 
     loadWeather();
-  }, [fetchWeatherData]);
+  }, [fetchWeatherData, initialData]);
 
   return state;
 }

--- a/src/shared/components/Carousel/Carousel.module.scss
+++ b/src/shared/components/Carousel/Carousel.module.scss
@@ -7,10 +7,6 @@
   align-self: flex-start;
   box-sizing: border-box;
   color: var(--text);
-
-  svg {
-    stroke: currentColor;
-  }
 }
 
 .carousel {

--- a/src/shared/components/Clock/Clock.tsx
+++ b/src/shared/components/Clock/Clock.tsx
@@ -3,7 +3,12 @@
 import React, { useEffect, useState } from 'react';
 import { Clock as ClockIcon } from 'lucide-react';
 
-import { getBeforeLunchMessage, getAfterLunchMessage, getDinnerTimeMessage } from './clockMessages';
+import {
+  getBeforeLunchMessage,
+  getAfterLunchMessage,
+  getDinnerTimeMessage,
+  loadingMessage,
+} from './clockMessages';
 
 import styles from './Clock.module.scss';
 
@@ -52,8 +57,8 @@ function formatCurrentTime(date: Date) {
 }
 
 export default function Clock() {
-  const [currentTime, setCurrentTime] = useState(formatCurrentTime(new Date()));
-  const [message, setMessage] = useState('');
+  const [currentTime, setCurrentTime] = useState<string>('');
+  const [message, setMessage] = useState(loadingMessage);
   const [phase, setPhase] = useState<MealPhase | null>(null);
 
   useEffect(() => {
@@ -64,16 +69,17 @@ export default function Clock() {
 
       setCurrentTime(formatCurrentTime(now));
 
+      // 시간대가 바뀔 때만 메시지 갱신
       if (phase !== nextPhase) {
         setPhase(nextPhase);
-      }
 
-      if (nextPhase === 'beforeLunch') {
-        setMessage(getBeforeLunchMessage(nextRemain));
-      } else if (nextPhase === 'afterLunch') {
-        setMessage(getAfterLunchMessage());
-      } else {
-        setMessage(getDinnerTimeMessage());
+        if (nextPhase === 'beforeLunch') {
+          setMessage(getBeforeLunchMessage(nextRemain));
+        } else if (nextPhase === 'afterLunch') {
+          setMessage(getAfterLunchMessage());
+        } else {
+          setMessage(getDinnerTimeMessage());
+        }
       }
     };
 
@@ -90,11 +96,12 @@ export default function Clock() {
           <span className={styles['clock__message']}>{message}</span>
         </div>
 
-        <div className={styles['clock__time-wrap']}>
-          <ClockIcon className={styles['clock__icon']} aria-hidden="true" />
-
-          <span className={styles['clock__time']}>{currentTime}</span>
-        </div>
+        {currentTime && (
+          <div className={styles['clock__time-wrap']}>
+            <ClockIcon className={styles['clock__icon']} aria-hidden="true" />
+            <span className={styles['clock__time']}>{currentTime}</span>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/shared/components/Clock/Clock.tsx
+++ b/src/shared/components/Clock/Clock.tsx
@@ -22,16 +22,18 @@ function getMealPhase(): MealPhase {
   dinner.setHours(DINNER_TIME.hour, DINNER_TIME.minute, 0, 0);
 
   if (now < lunch) return 'beforeLunch';
-  if (now >= lunch && now < dinner) return 'afterLunch';
+  if (now < dinner) return 'afterLunch';
   return 'dinnerTime';
 }
 
 function calcRemain() {
   const now = new Date();
+
   const lunch = new Date();
   lunch.setHours(LUNCH_TIME.hour, LUNCH_TIME.minute, 0, 0);
 
   const diff = lunch.getTime() - now.getTime();
+
   if (diff <= 0) return 'passed';
 
   const h = String(Math.floor(diff / 1000 / 60 / 60)).padStart(2, '0');
@@ -45,62 +47,67 @@ function formatCurrentTime(date: Date) {
   const h = String(date.getHours()).padStart(2, '0');
   const m = String(date.getMinutes()).padStart(2, '0');
   const s = String(date.getSeconds()).padStart(2, '0');
+
   return `${h}:${m}:${s}`;
 }
 
 export default function Clock() {
   const [currentTime, setCurrentTime] = useState('');
-  const [remain, setRemain] = useState('');
   const [message, setMessage] = useState('');
   const [phase, setPhase] = useState<MealPhase | null>(null);
 
   useEffect(() => {
     const tick = () => {
       const now = new Date();
+      const nextRemain = calcRemain();
+      const nextPhase = getMealPhase();
+
       setCurrentTime(formatCurrentTime(now));
-      setRemain(calcRemain());
+
+      if (phase !== nextPhase) {
+        setPhase(nextPhase);
+
+        if (nextPhase === 'beforeLunch') {
+          setMessage(getBeforeLunchMessage(nextRemain));
+        }
+
+        if (nextPhase === 'afterLunch') {
+          setMessage(getAfterLunchMessage());
+        }
+
+        if (nextPhase === 'dinnerTime') {
+          setMessage(getDinnerTimeMessage());
+        }
+      }
     };
 
     tick();
     const interval = setInterval(tick, 1000);
+
     return () => clearInterval(interval);
-  }, []);
+  }, [phase]);
 
-  // 상태 변화 시 메시지 1회 설정
-  useEffect(() => {
-    if (!remain) return;
-
-    const nextPhase = getMealPhase();
-    if (phase === nextPhase) return;
-
-    let nextMessage = '';
-
-    if (nextPhase === 'beforeLunch') {
-      nextMessage = getBeforeLunchMessage(remain);
-    }
-
-    if (nextPhase === 'afterLunch') {
-      nextMessage = getAfterLunchMessage();
-    }
-
-    if (nextPhase === 'dinnerTime') {
-      nextMessage = getDinnerTimeMessage();
-    }
-
-    setPhase(nextPhase);
-    setMessage(nextMessage);
-  }, [remain, phase]);
+  const isLoading = !currentTime;
 
   return (
     <section className={styles['clock']}>
       <div className={styles['clock__wrapper']}>
         <div className={styles['clock__header']}>
-          <span className={styles['clock__message']}>{message}</span>
+          <span className={styles['clock__message']}>
+            {isLoading ? '시간을 확인하는 중...' : message}
+          </span>
         </div>
 
         <div className={styles['clock__time-wrap']}>
           <ClockIcon className={styles['clock__icon']} aria-hidden="true" />
-          <span className={styles['clock__time']}>{currentTime}</span>
+
+          <span
+            className={`${styles['clock__time']} ${
+              isLoading ? styles['clock__time--skeleton'] : ''
+            }`}
+          >
+            {isLoading ? '00:00:00' : currentTime}
+          </span>
         </div>
       </div>
     </section>

--- a/src/shared/components/Clock/Clock.tsx
+++ b/src/shared/components/Clock/Clock.tsx
@@ -52,7 +52,7 @@ function formatCurrentTime(date: Date) {
 }
 
 export default function Clock() {
-  const [currentTime, setCurrentTime] = useState('');
+  const [currentTime, setCurrentTime] = useState(formatCurrentTime(new Date()));
   const [message, setMessage] = useState('');
   const [phase, setPhase] = useState<MealPhase | null>(null);
 
@@ -83,27 +83,17 @@ export default function Clock() {
     return () => clearInterval(interval);
   }, [phase]);
 
-  const isLoading = !currentTime;
-
   return (
     <section className={styles['clock']}>
       <div className={styles['clock__wrapper']}>
         <div className={styles['clock__header']}>
-          <span className={styles['clock__message']}>
-            {isLoading ? '시간을 확인하는 중...' : message}
-          </span>
+          <span className={styles['clock__message']}>{message}</span>
         </div>
 
         <div className={styles['clock__time-wrap']}>
           <ClockIcon className={styles['clock__icon']} aria-hidden="true" />
 
-          <span
-            className={`${styles['clock__time']} ${
-              isLoading ? styles['clock__time--skeleton'] : ''
-            }`}
-          >
-            {isLoading ? '00:00:00' : currentTime}
-          </span>
+          <span className={styles['clock__time']}>{currentTime}</span>
         </div>
       </div>
     </section>

--- a/src/shared/components/Clock/Clock.tsx
+++ b/src/shared/components/Clock/Clock.tsx
@@ -66,18 +66,14 @@ export default function Clock() {
 
       if (phase !== nextPhase) {
         setPhase(nextPhase);
+      }
 
-        if (nextPhase === 'beforeLunch') {
-          setMessage(getBeforeLunchMessage(nextRemain));
-        }
-
-        if (nextPhase === 'afterLunch') {
-          setMessage(getAfterLunchMessage());
-        }
-
-        if (nextPhase === 'dinnerTime') {
-          setMessage(getDinnerTimeMessage());
-        }
+      if (nextPhase === 'beforeLunch') {
+        setMessage(getBeforeLunchMessage(nextRemain));
+      } else if (nextPhase === 'afterLunch') {
+        setMessage(getAfterLunchMessage());
+      } else {
+        setMessage(getDinnerTimeMessage());
       }
     };
 

--- a/src/shared/components/Clock/clockMessages.ts
+++ b/src/shared/components/Clock/clockMessages.ts
@@ -1,5 +1,7 @@
 import { formatRemain } from './formatRemain';
 
+export const loadingMessage = '지금 시간 불러오는 중...';
+
 const beforeLunchMessages = [
   (remain: string) => `점심시간까지 ${formatRemain(remain)} 남았다!`,
   (remain: string) => `오늘 뭐 먹을지 정했나? ${formatRemain(remain)} 남았어`,

--- a/src/shared/components/TopTabs/TopTabs.module.scss
+++ b/src/shared/components/TopTabs/TopTabs.module.scss
@@ -10,6 +10,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   box-shadow: 0 6px 12px 0 rgb(0 0 0 / 8%);
+
   &__list {
     display: flex;
     width: 100%;
@@ -22,7 +23,11 @@
     padding: 12px 0;
     background: transparent;
     border-radius: 8px;
+
     @include m.text-style-extended('lg', 500, text-default);
+
+    color: var(--text-secondary);
+
     cursor: pointer;
     transition: all 0.2s ease;
 
@@ -32,19 +37,14 @@
     }
 
     &:hover {
-      background: f.color(orange-700);
-      color: f.color(white);
+      color: f.color(orange-700);
+      background: transparent;
     }
 
     &--active {
-      @include m.text-style-extended('lg', 500, orange-700);
+      color: f.color(orange-700);
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
       border-bottom: 3px solid f.color(orange-700);
-    }
-
-    &:hover {
-      background: transparent;
-      color: f.color(orange-700);
     }
   }
 
@@ -55,8 +55,9 @@
 
   &__label {
     @include m.text-style-extended('lg', 500, text-default);
-    color: var(--text-secondary);
+    color: inherit;
   }
+
   &__panel {
     flex: 1 1 auto;
     min-height: 0;

--- a/src/shared/components/TopTabs/TopTabs.module.scss
+++ b/src/shared/components/TopTabs/TopTabs.module.scss
@@ -7,7 +7,8 @@
   flex-direction: column;
   width: 100%;
   border-radius: 24px;
-  border: 1.5px solid f.color(gray-100);
+  background: var(--surface);
+  border: 1px solid var(--border);
   box-shadow: 0 6px 12px 0 rgb(0 0 0 / 8%);
   &__list {
     display: flex;
@@ -54,6 +55,7 @@
 
   &__label {
     @include m.text-style-extended('lg', 500, text-default);
+    color: var(--text-secondary);
   }
   &__panel {
     flex: 1 1 auto;

--- a/src/shared/components/layout/Header/Header.module.scss
+++ b/src/shared/components/layout/Header/Header.module.scss
@@ -69,7 +69,6 @@
   &__theme-toggle {
     width: 32px;
     height: 32px;
-    border: 1px solid var(--border);
     border-radius: 8px;
     background: var(--surface);
     color: var(--text);

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -1,6 +1,9 @@
 @use 'utils/functions' as f;
 
 :root {
+  --skeleton-base: #e5e7eb;
+  --skeleton-highlight: #f3f4f6;
+
   --bg: #{f.color(white)};
   --surface: #{f.color(gray-100)};
   --surface-2: #{f.color(white)};
@@ -13,6 +16,9 @@
 }
 
 html[data-theme='dark'] {
+  --skeleton-base: #2a2a2a;
+  --skeleton-highlight: #3a3a3a;
+
   --bg: #{f.color(gray-900)};
   --surface: #{f.color(gray-800)};
   --surface-2: #{f.color(gray-900)};

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -4,6 +4,7 @@
 @use 'utils/mixins';
 @use 'utils/variables';
 @use 'utils/functions';
+@use 'utils/skeleton';
 @use 'theme';
 
 // 스크롤바가 생기거나 사라질 때도 화면 레이아웃 폭을 고정

--- a/src/styles/utils/_skeleton.scss
+++ b/src/styles/utils/_skeleton.scss
@@ -1,0 +1,22 @@
+@keyframes skeleton-loading {
+  0% {
+    background-position: -200px 0;
+  }
+
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+}
+
+// CSS Modules 에서 안전하게 @extend 할 수 있도록 placeholder 로 정의
+%skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-base) 25%,
+    var(--skeleton-highlight) 37%,
+    var(--skeleton-base) 63%
+  );
+  background-size: 400px 100%;
+  animation: skeleton-loading 1.4s infinite linear;
+  border-radius: 8px;
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
메인 페이지의 렌더링 구조를 정리하여 Server Component와 Client Component의 역할을 명확히 분리했습니다.
- Clock 컴포넌트에서 발생하던 hydration mismatch 문제 해결
- 서버에서 추천 메뉴와 날씨 데이터를 조회하도록 구조 개선
- 캐러셀 및 기분 카드 인터랙션을 Client Component로 분리
- 초기 렌더링 시 UI 표시 지연을 완화하도록 렌더링 흐름 정리
- 로딩 UI 처리를 위해 skeleton.scss 파일 추가

## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1. 메인 페이지 접속
2. 콘솔에서 hydration 오류 발생 여부 확인
3. 페이지 새로고침 시 추천 메뉴 / 날씨 데이터 정상 렌더링 확인

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#161 
## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
이번 리팩토링을 통해 데이터 조회는 Server Component, UI 인터랙션은 Client Component를 초기 렌더링 안정성과 유지보수성을 개선했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 서버사이드 병렬 프리로딩으로 홈 초기 렌더링 속도 향상 및 MainClient에 초기 데이터(initialTopMenus, initialCarouselItems, initialWeatherData) 전달 지원.
  * 날씨 추천에 초기 데이터 지원과 스켈레톤 로더 추가.

* **스타일**
  * 스켈레톤 관련 SCSS·테마 변수 추가 및 탭·헤더 토글 등 UI 색상·경계 조정.

* **기타**
  * 메시지 카드에 사용자용 로딩 텍스트 추가 및 시계 표시/갱신 로직 간소화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->