### PR TITLE
[refactor/165-logout-auth] - 로그아웃 이후 불필요한 api 제거

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,5 +1,4 @@
-﻿import { redirect } from 'next/navigation';
-import type { Metadata } from 'next';
+﻿import type { Metadata } from 'next';
 import { authServiceServer } from '@/services/backend/auth.api';
 import { favoritesServiceServer } from '@/services/backend/favorites.api';
 import { getMyFoodDotsServer } from '@/services/backend/users.api';

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -29,49 +29,46 @@ export const metadata: Metadata = {
  * @description 이 페이지는 서버 컴포넌트입니다. 클라이언트 컴포넌트로 변경하지 마세요.
  */
 export default async function Page() {
-  try {
-    const user = await authServiceServer.getMe();
-    if (!user) redirect('/');
+  const queryClient = new QueryClient();
 
-    const queryClient = new QueryClient();
+  const user = await authServiceServer.getMe();
 
-    // 사용자 정보 캐싱
+  // middleware가 이미 보호하므로 null 처리만
+  if (user) {
     queryClient.setQueryData(['me'], user);
-
-    await Promise.allSettled([
-      queryClient.prefetchQuery({
-        queryKey: ['favorites'],
-        queryFn: () => favoritesServiceServer.getMyFavorites(),
-      }),
-      queryClient.prefetchQuery({
-        queryKey: ['foodDots'],
-        queryFn: () => getMyFoodDotsServer(),
-      }),
-      queryClient.prefetchQuery({
-        queryKey: ['preference'],
-        queryFn: () => favoritesServiceServer.getMyPreference(),
-      }),
-    ]);
-
-    return (
-      <div className={styles['mypage']}>
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <MyPageHeader />
-          <main className={styles['mypage__content']}>
-            <div className={styles['mypage__top']}>
-              <FoodDotSelectionCard />
-              <FavoriteMenuCard />
-            </div>
-
-            <div className={styles['mypage__bottom']}>
-              <MenuSummaryCard />
-              <AccountSetting />
-            </div>
-          </main>
-        </HydrationBoundary>
-      </div>
-    );
-  } catch {
-    redirect('/');
   }
+
+  await Promise.allSettled([
+    queryClient.prefetchQuery({
+      queryKey: ['favorites'],
+      queryFn: () => favoritesServiceServer.getMyFavorites(),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ['foodDots'],
+      queryFn: () => getMyFoodDotsServer(),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ['preference'],
+      queryFn: () => favoritesServiceServer.getMyPreference(),
+    }),
+  ]);
+
+  return (
+    <div className={styles['mypage']}>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <MyPageHeader />
+        <main className={styles['mypage__content']}>
+          <div className={styles['mypage__top']}>
+            <FoodDotSelectionCard />
+            <FavoriteMenuCard />
+          </div>
+
+          <div className={styles['mypage__bottom']}>
+            <MenuSummaryCard />
+            <AccountSetting />
+          </div>
+        </main>
+      </HydrationBoundary>
+    </div>
+  );
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -9,8 +9,9 @@ import FoodDotSelectionCard from '@/features/Mypage/FoodDotSelectionCard/FoodDot
 import FavoriteMenuCard from '@/features/Mypage/FavoriteMenuCard';
 import MenuSummaryCard from '@/features/Mypage/MenuSummaryCard';
 import AccountSetting from '@/features/Mypage/AccountSetting';
-import styles from './page.module.scss';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+
+import styles from './page.module.scss';
 
 export const metadata: Metadata = {
   title: '마이페이지',
@@ -29,13 +30,15 @@ export const metadata: Metadata = {
  */
 export default async function Page() {
   try {
+    const user = await authServiceServer.getMe();
+    if (!user) redirect('/');
+
     const queryClient = new QueryClient();
 
+    // 사용자 정보 캐싱
+    queryClient.setQueryData(['me'], user);
+
     await Promise.allSettled([
-      queryClient.prefetchQuery({
-        queryKey: ['me'],
-        queryFn: () => authServiceServer.getMe(),
-      }),
       queryClient.prefetchQuery({
         queryKey: ['favorites'],
         queryFn: () => favoritesServiceServer.getMyFavorites(),

--- a/src/features/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
+++ b/src/features/Mypage/AccountSetting/EditProfile/EditProfileForm.tsx
@@ -1,7 +1,7 @@
 ﻿'use client';
 
 import { useEffect, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 
 import BaseInput from '@/shared/components/Input/BaseInput/BaseInput';
@@ -33,6 +33,7 @@ export default function EditProfileForm({
   onCancel,
 }: EditProfileFormProps) {
   const setUser = useAuthStore(state => state.setUser);
+  const queryClient = useQueryClient();
 
   const [formState, setFormState] = useState<EditProfileFormState>({
     nickname: '',
@@ -56,8 +57,13 @@ export default function EditProfileForm({
 
   const updateMeMutation = useMutation({
     mutationFn: (data: Auth.UpdateMeReq) => authServiceClient.updateMe(data),
-    onSuccess: updatedUser => {
+
+    // 성공 시 사용자 정보 갱신
+    onSuccess: async updatedUser => {
       setUser(updatedUser);
+
+      await queryClient.invalidateQueries({ queryKey: ['me'] });
+
       toast.success('회원 정보가 수정되었습니다.');
       onSubmitSuccess();
     },

--- a/src/features/Mypage/AccountSetting/LogoutModal/LogoutModal.tsx
+++ b/src/features/Mypage/AccountSetting/LogoutModal/LogoutModal.tsx
@@ -38,7 +38,6 @@ export default function LogoutModal({ isOpen, onClose }: LogoutModalProps) {
       onClose();
 
       router.push('/');
-      router.refresh();
     },
     onError: error => {
       console.error('[LogoutModal] 로그아웃 실패:', error);

--- a/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
+++ b/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
@@ -43,7 +43,7 @@ const MyPageHeader = () => {
   const router = useRouter();
 
   const { data: user } = useQuery({
-    queryKey: ['me'],
+    queryKey: ['users', 'me'],
     queryFn: authServiceClient.getMe,
     retry: false,
   });

--- a/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
+++ b/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
@@ -42,8 +42,8 @@ const MyPageHeader = () => {
 
   const router = useRouter();
 
-  const { data: user } = useQuery({
-    queryKey: ['users', 'me'],
+  const { data: user, isPending } = useQuery({
+    queryKey: ['me'],
     queryFn: authServiceClient.getMe,
   });
 
@@ -71,10 +71,10 @@ const MyPageHeader = () => {
   const [displayImage, setDisplayImage] = useState(displayUser.profileImage);
 
   useEffect(() => {
-    if (!user) {
+    if (!isPending && !user) {
       router.replace('/');
     }
-  }, [user, router]);
+  }, [user, isPending, router]);
 
   useEscClose(isMenuOpen ? () => setIsMenuOpen(false) : undefined);
 

--- a/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
+++ b/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
@@ -40,30 +40,37 @@ const MyPageHeader = () => {
 
   const updateProfileImage = useAuthStore(state => state.updateProfileImage);
 
+  const router = useRouter();
+
+  const { data: user } = useQuery({
+    queryKey: ['me'],
+    queryFn: authServiceClient.getMe,
+    retry: false,
+  });
+
   const { data: selectedDotIds = [] } = useQuery({
     queryKey: ['foodDots'],
     queryFn: () => getMyFoodDots(),
+    enabled: !!user,
+    retry: false,
   });
 
   const selectedDots = selectedDotIds
     .map(id => FOOD_DOTS.find(dot => dot.id === id))
     .filter((dot): dot is (typeof FOOD_DOTS)[number] => dot !== undefined);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const avatarRef = useRef<HTMLDivElement>(null);
-  const firstMenuItemRef = useRef<HTMLButtonElement>(null);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  const { data: user } = useQuery({
-    queryKey: ['me'],
-    queryFn: authServiceClient.getMe,
-  });
-
   const displayUser = user || DEFAULT_USER_FALLBACK;
   const isDefaultImage =
     !displayUser.profileImage || displayUser.profileImage === DEFAULT_PROFILE_IMAGE_PATH;
 
-  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const avatarRef = useRef<HTMLDivElement>(null);
+  const firstMenuItemRef = useRef<HTMLButtonElement>(null);
+  const previewUrlRef = useRef<string | null>(null);
+
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [displayNickname, setDisplayNickname] = useState(displayUser.nickname);
+  const [displayImage, setDisplayImage] = useState(displayUser.profileImage);
 
   useEffect(() => {
     if (!user) {
@@ -123,28 +130,26 @@ const MyPageHeader = () => {
     }
 
     try {
-      // 이전 미리보기 URL 정리
       if (previewUrlRef.current) {
         URL.revokeObjectURL(previewUrlRef.current);
         previewUrlRef.current = null;
       }
-      // 낙관적 업데이트
+
       const previewUrl = URL.createObjectURL(file);
       previewUrlRef.current = previewUrl;
+
       setDisplayImage(previewUrl);
       updateProfileImage(previewUrl);
 
-      // 서버 업로드 → 실제 URL 수신
       const uploadedUrl = await uploadProfileImage(file);
+
       if (!uploadedUrl) {
         throw new Error('업로드 결과 URL 없음');
       }
 
-      // 실제 URL로 교체
       setDisplayImage(uploadedUrl);
       updateProfileImage(uploadedUrl);
 
-      // blob URL 정리
       if (previewUrlRef.current) {
         URL.revokeObjectURL(previewUrlRef.current);
         previewUrlRef.current = null;
@@ -152,18 +157,15 @@ const MyPageHeader = () => {
 
       toast.success('프로필 이미지가 변경되었습니다.');
 
-      // 서버 데이터 갱신 요청
       await queryClient.invalidateQueries({ queryKey: ['users', 'me'] });
     } catch {
       toast.error('이미지 변경 실패. 잠시 후 다시 시도해주세요.');
 
-      // 실패 시 blob URL 정리
       if (previewUrlRef.current) {
         URL.revokeObjectURL(previewUrlRef.current);
         previewUrlRef.current = null;
       }
 
-      // 원래 이미지로 복구
       setDisplayImage(displayUser.profileImage);
       updateProfileImage(displayUser.profileImage || null);
     } finally {
@@ -171,23 +173,18 @@ const MyPageHeader = () => {
     }
   };
 
-  const [displayNickname, setDisplayNickname] = useState(displayUser.nickname);
-  const [displayImage, setDisplayImage] = useState(displayUser.profileImage);
-
-  // preview URL 관리 (메모리 누수 방지)
-  const previewUrlRef = useRef<string | null>(null);
-
-  // user가 바뀌면 동기화 (닉네임 & 이미지)
   useEffect(() => {
     setDisplayNickname(displayUser.nickname);
     setDisplayImage(displayUser.profileImage);
   }, [displayUser.nickname, displayUser.profileImage]);
 
-  // 실시간 업데이트 이벤트 리스너
+  // 실시간 닉네임/프로필 이미지 업데이트 감지
   useEffect(() => {
     const nicknameHandler = (e: Event) => {
       const customEvent = e as CustomEvent<{ nickname: string }>;
-      if (customEvent.detail?.nickname) setDisplayNickname(customEvent.detail.nickname);
+      if (customEvent.detail?.nickname) {
+        setDisplayNickname(customEvent.detail.nickname);
+      }
     };
     const imageHandler = (e: Event) => {
       const customEvent = e as CustomEvent<{ profileImage: string | null }>;
@@ -198,8 +195,10 @@ const MyPageHeader = () => {
         setDisplayImage(customEvent.detail.profileImage);
       }
     };
+
     window.addEventListener('profile:nicknameUpdated', nicknameHandler as EventListener);
     window.addEventListener('profile:imageUpdated', imageHandler as EventListener);
+
     return () => {
       window.removeEventListener('profile:nicknameUpdated', nicknameHandler as EventListener);
       window.removeEventListener('profile:imageUpdated', imageHandler as EventListener);
@@ -266,6 +265,7 @@ const MyPageHeader = () => {
         <h1 className={styles['profile-header__title']} id="profile-header-title">
           {displayNickname}님의 마이페이지
         </h1>
+
         <p className={styles['profile-header__subtitle']}>오늘 기록이 여기에 정리돼요</p>
 
         <div className={styles['profile-header__stats']}>
@@ -273,6 +273,7 @@ const MyPageHeader = () => {
             <Badge key={id} id={id} variant={variant} Icon={Icon} text={text} />
           ))}
         </div>
+
         {selectedDots.length > 0 && (
           <div className={styles['profile-header__food-dots']}>
             {selectedDots.map(dot => (

--- a/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
+++ b/src/features/Mypage/MyPageHeader/MyPageHeader.tsx
@@ -45,14 +45,12 @@ const MyPageHeader = () => {
   const { data: user } = useQuery({
     queryKey: ['users', 'me'],
     queryFn: authServiceClient.getMe,
-    retry: false,
   });
 
   const { data: selectedDotIds = [] } = useQuery({
     queryKey: ['foodDots'],
     queryFn: () => getMyFoodDots(),
     enabled: !!user,
-    retry: false,
   });
 
   const selectedDots = selectedDotIds

--- a/src/features/Roulette/components/RouletteFilter/RouletteFilter.module.scss
+++ b/src/features/Roulette/components/RouletteFilter/RouletteFilter.module.scss
@@ -7,36 +7,38 @@
     width: fit-content;
     margin: 0 auto;
     padding: 4px;
-    background: f.color(gray-100);
+    background: var(--surface);
     border-radius: 32px;
+  }
 
-    &__tab {
-      width: 100px;
+  &__mode__tab {
+    width: 100px;
+    height: 36px;
+    @include m.flex-box(center, center);
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: transparent;
+    border-radius: 32px;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    @include m.mq(md) {
+      width: 200px;
       height: 36px;
-      @include m.flex-box(center, center);
-      @include m.text-style-extended(md, 600, gray-700);
-      background: transparent;
-      border-radius: 32px;
-      cursor: pointer;
-      transition: all 0.2s ease;
+    }
 
-      @include m.mq(md) {
-        width: 200px;
-        height: 36px;
-      }
+    @include m.mq(lg) {
+      @include m.text-style(lg, 600);
+      width: 260px;
+      height: 48px;
+    }
 
-      @include m.mq(lg) {
-        @include m.text-style(lg, 600);
-        width: 260px;
-        height: 48px;
-      }
-
-      &--active {
-        background: f.color(point-blue);
-        color: f.color(text-inverse);
-        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.18);
-        transform: translateY(-2px);
-      }
+    &--active {
+      background: f.color(point-blue);
+      color: f.color(text-inverse);
+      border: none;
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.18);
     }
   }
 
@@ -51,31 +53,31 @@
     @include m.mq(md) {
       gap: 12px;
     }
+  }
 
-    &__item {
-      @include m.flex-box(center, center);
-      border-radius: 16px;
-      @include m.text-style(xs, 400);
-      height: 32px;
-      padding: 0 12px;
-      box-sizing: border-box;
+  &__options__item {
+    @include m.flex-box(center, center);
+    border-radius: 16px;
+    @include m.text-style(xs, 400);
+    height: 32px;
+    padding: 0 12px;
+    box-sizing: border-box;
 
-      @include m.mq(md) {
-        @include m.text-style(sm, 400);
-        height: 36px;
-        padding: 0 14px;
-      }
-
-      @include m.mq(lg) {
-        @include m.text-style(md, 400);
-        height: 40px;
-        padding: 0 18px;
-      }
-
-      &__icon {
-        @include m.flex-box(center, center);
-        margin-right: 6px;
-      }
+    @include m.mq(md) {
+      @include m.text-style(sm, 400);
+      height: 36px;
+      padding: 0 14px;
     }
+
+    @include m.mq(lg) {
+      @include m.text-style(md, 400);
+      height: 40px;
+      padding: 0 18px;
+    }
+  }
+
+  &__options__item__icon {
+    @include m.flex-box(center, center);
+    margin-right: 6px;
   }
 }

--- a/src/features/Roulette/components/RouletteFilter/RouletteFilter.tsx
+++ b/src/features/Roulette/components/RouletteFilter/RouletteFilter.tsx
@@ -116,7 +116,7 @@ export default function RouletteFilter({
               className={styles['filter__options__item']}
               onClick={() => toggleFoodType(opt.value as Category)}
             >
-              {opt.icon}
+              <span className={styles['filter__options__item__icon']}>{opt.icon}</span>
               {opt.label}
             </Button>
           ))}
@@ -133,7 +133,7 @@ export default function RouletteFilter({
               className={styles['filter__options__item']}
               onClick={() => toggleSituation(opt.value as Context)}
             >
-              {opt.icon}
+              <span className={styles['filter__options__item__icon']}>{opt.icon}</span>
               {opt.label}
             </Button>
           ))}

--- a/src/features/Roulette/components/RouletteModal/RouletteModal.module.scss
+++ b/src/features/Roulette/components/RouletteModal/RouletteModal.module.scss
@@ -39,5 +39,18 @@
       width: 100%;
       border-radius: 12px;
     }
+
+    /* 닫기 버튼 */
+    :global(button:last-child) {
+      border: 1px solid var(--border);
+      color: var(--text-secondary);
+      background: transparent;
+
+      &:hover {
+        border: 1px solid var(--border);
+        color: var(--text);
+        background: var(--surface-hover);
+      }
+    }
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 로그아웃 이후 사용자 관련 query가 실행되지 않도록 구조 개선
- 불필요한 refresh 요청 및 401 네트워크 요청 제거
- 인증 redirect 로직을 middleware로 통합
- 서버와 클라이언트에서 다른 queryKey를 사용하는 경우 cache miss가 발생하여 queryKey를 ['me']로 통일
## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#165 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃 후 불필요한 페이지 새로고침 제거로 홈 이동이 더 빠르고 부드러워짐

* **새로운 기능**
  * 서버측 사용자 조회 및 캐시 기반 초기화·미사용 시 리다이렉트 처리 추가
  * 프로필 이미지 즉시 미리보기·업로드(오류 시 롤백 포함) 및 실제 URL로 교체되는 흐름
  * 닉네임·이미지의 실시간 외부 업데이트 동기화
  * 프로필 수정 후 사용자 캐시(invalidate) 동기화 처리 추가
  * 파일 선택/리셋, 미리보기 URL 정리 및 키보드 포커스 개선으로 접근성 향상

* **스타일**
  * 룰렛 필터 및 모달 닫기 버튼 UI/스타일 개선 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->