### PR TITLE
[refactor/167-responsive-layout-improvement] - 메인, 혼자정하기, 같이정하기, 마이페이지, 모달 반응형 개선

### DIFF
--- a/src/app/rooms/[roomId]/page.module.scss
+++ b/src/app/rooms/[roomId]/page.module.scss
@@ -9,9 +9,10 @@
 
   &__header {
     flex-shrink: 0;
-    @include m.flex-box(space-between, center);
+    @include m.flex-box(flex-start, stretch, column);
     width: 100%;
-    padding: 24px 28px;
+    gap: 10px;
+    padding: 16px;
     border-radius: 24px;
     background: var(--surface);
     border: 1.5px solid var(--border);
@@ -19,29 +20,55 @@
     color: var(--text);
     transition: all 0.3s ease;
 
+    @include m.mq(sm) {
+      gap: 0;
+      padding: 24px 28px;
+      @include m.flex-box(space-between, center);
+    }
+
     @include m.mq(md) {
       @include m.flex-box(space-between, center);
     }
 
     &__left {
       @include m.flex-box(flex-start, center);
-      gap: 14px;
+      gap: 10px;
+      width: 100%;
+      min-width: 0;
+
+      @include m.mq(sm) {
+        gap: 14px;
+      }
+
+      > div {
+        min-width: 0;
+      }
     }
 
     &__icon {
-      width: 56px;
-      height: 56px;
-      border-radius: 14px;
-      padding: 10px;
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
+      padding: 8px;
       background-color: f.color(orange-100);
       color: f.color(orange-700);
       box-shadow: 0 4px 12px rgba(f.color(orange-700), 0.25);
+
+      @include m.mq(sm) {
+        width: 56px;
+        height: 56px;
+        border-radius: 14px;
+        padding: 10px;
+      }
     }
   }
 
   &__title {
     @include m.text-style('md', 700);
     color: var(--text);
+    min-width: 0;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 
     @include m.mq(md) {
       @include m.text-style('xl', 700);
@@ -52,6 +79,9 @@
     @include m.text-style-extended('xs', 500, gray-700);
     color: var(--text-secondary);
     margin-top: 4px;
+    min-width: 0;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 
     @include m.mq(md) {
       @include m.text-style('sm', 500);
@@ -60,48 +90,72 @@
 
   &__code {
     width: 100%;
+    max-width: 100%;
+    align-self: stretch;
     @include m.flex-box(space-between, center);
-    gap: 10px;
-    padding: 8px 16px;
+    gap: 8px;
+    padding: 6px 10px;
     border-radius: 999px;
     background: color-mix(in srgb, var(--surface-2) 85%, transparent);
     backdrop-filter: blur(10px);
     border: 2px solid color-mix(in srgb, var(--border) 60%, transparent);
     box-shadow: var(--shadow);
 
-    @include m.mq(md) {
+    @include m.mq(sm) {
       width: fit-content;
+      max-width: none;
+      align-self: auto;
+      gap: 10px;
+      padding: 8px 16px;
     }
 
     &__label {
       @include m.text-style-extended('xs', 600, gray-700);
       color: var(--text-secondary);
+      white-space: nowrap;
+      flex-shrink: 0;
     }
 
     &__value {
-      @include m.flex-box(space-between, center);
-      gap: 16px;
+      @include m.flex-box(flex-start, center);
+      gap: 8px;
+      min-width: 0;
+      flex-shrink: 0;
+
+      @include m.mq(sm) {
+        gap: 16px;
+      }
 
       &__inner {
         @include m.text-style-extended('sm', 700, gray-700);
         color: var(--text);
-        letter-spacing: 0.1em;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+
+        @include m.mq(sm) {
+          letter-spacing: 0.1em;
+        }
       }
     }
 
     &__copy {
       @include m.flex-box(center, center);
       gap: 4px;
-      padding: 6px 12px;
+      padding: 4px 8px;
       border-radius: 999px;
-      border: none;
+      border: 1px solid var(--border);
       background: var(--surface-2);
       cursor: pointer;
       @include m.text-style-extended('xs', 600, gray-700);
       color: var(--text-secondary);
       box-shadow: var(--shadow);
-      border: 1px solid var(--border);
       transition: all 0.2s ease;
+      white-space: nowrap;
+      flex-shrink: 0;
+
+      @include m.mq(sm) {
+        padding: 6px 12px;
+      }
 
       &:hover {
         box-shadow: var(--shadow);
@@ -117,10 +171,14 @@
     flex: 1;
     min-height: 0;
     display: grid;
-    grid-template-rows: 1fr 0.7fr;
-
-    gap: 20px;
+    grid-template-rows: minmax(360px, auto) minmax(460px, auto);
+    gap: 16px;
     width: 100%;
+
+    @include m.mq(sm) {
+      grid-template-rows: minmax(420px, auto) minmax(560px, auto);
+      gap: 20px;
+    }
 
     @include m.mq(lg) {
       grid-template-columns: 2fr 1fr;
@@ -165,12 +223,14 @@
     border-radius: 24px;
     border: 1.5px solid var(--border);
     box-shadow: var(--shadow);
-    transition:
-      box-shadow 0.2s,
-      border-color 0.2s;
-    padding: 24px;
-    gap: 16px;
+    padding: 16px;
+    gap: 12px;
     transition: all 0.3s ease;
+
+    @include m.mq(sm) {
+      padding: 24px;
+      gap: 16px;
+    }
   }
 
   &__result-section {
@@ -245,15 +305,21 @@
     box-shadow: var(--shadow);
 
     &__icon {
-      font-size: 36px;
-      width: 56px;
-      height: 56px;
-      @include m.flex-box(center, center);
-      background: var(--surface-2);
-      border-radius: 14px;
-      border: 1px solid var(--border);
-      box-shadow: var(--shadow);
-      color: var(--text-secondary);
+      flex-shrink: 0;
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
+      padding: 8px;
+      background-color: f.color(orange-100);
+      color: f.color(orange-700);
+      box-shadow: 0 4px 12px rgba(f.color(orange-700), 0.25);
+
+      @include m.mq(sm) {
+        width: 56px;
+        height: 56px;
+        border-radius: 14px;
+        padding: 10px;
+      }
     }
 
     &__info {
@@ -417,7 +483,7 @@
   &__right {
     width: 100%;
     min-height: 0;
-    max-height: 870px;
+    max-height: 460px;
     background: var(--surface);
     border-radius: 24px;
     border: 1.5px solid var(--border);
@@ -428,6 +494,14 @@
     flex: 1 1 0%;
     overflow: hidden;
     transition: all 0.3s ease;
+
+    @include m.mq(sm) {
+      max-height: 760px;
+    }
+
+    @include m.mq(lg) {
+      max-height: 870px;
+    }
   }
 
   &__loading {

--- a/src/app/rooms/solo/page.module.scss
+++ b/src/app/rooms/solo/page.module.scss
@@ -38,14 +38,24 @@
         @include m.flex-box(center, flex-start, column);
         gap: 4px;
 
+        h1,
         h2 {
-          @include m.text-style('xl', 700);
+          @include m.text-style('lg', 700);
           color: var(--text);
+
+          @include m.mq(sm) {
+            @include m.text-style('xl', 700);
+          }
         }
 
         span {
-          @include m.text-style-extended('md', 500, gray-700);
+          @include m.text-style-extended('sm', 500, gray-700);
           color: var(--text-secondary);
+
+          @include m.mq(sm) {
+            @include m.text-style('md', 500);
+            color: var(--text);
+          }
         }
       }
     }
@@ -115,21 +125,34 @@
     margin-bottom: 16px;
 
     h3 {
-      @include m.text-style('lg', 700);
+      @include m.text-style('md', 700);
       color: var(--text);
       margin: 0;
+
+      @include m.mq(sm) {
+        @include m.text-style('lg', 700);
+      }
     }
 
     p {
-      @include m.text-style-extended('sm', 500, gray-700);
+      @include m.text-style-extended('xs', 500, gray-700);
       color: var(--text-secondary);
+
+      @include m.mq(sm) {
+        @include m.text-style('sm', 500);
+        color: var(--text);
+      }
     }
 
     &__search-btn {
       height: 44px;
       min-width: 80px;
       padding: 0 20px;
-      @include m.text-style('md', 600);
+      @include m.text-style('sm', 600);
+
+      @include m.mq(sm) {
+        @include m.text-style('md', 600);
+      }
 
       color: white;
       border: none;
@@ -178,9 +201,13 @@
     margin-bottom: 16px;
 
     h3 {
-      @include m.text-style('xl', 700);
+      @include m.text-style('lg', 700);
       color: var(--text);
       margin: 0;
+
+      @include m.mq(sm) {
+        @include m.text-style('xl', 700);
+      }
     }
   }
 
@@ -212,16 +239,24 @@
     }
 
     &__name {
-      @include m.text-style('lg', 600);
+      @include m.text-style('md', 600);
       color: var(--text-secondary);
+
+      @include m.mq(sm) {
+        @include m.text-style('lg', 600);
+      }
     }
 
     &__count {
-      @include m.text-style('md', 700);
+      @include m.text-style('sm', 700);
       color: var(--text-secondary);
       background: color-mix(in srgb, var(--border) 30%, transparent);
       padding: 6px 16px;
       border-radius: 999px;
+
+      @include m.mq(sm) {
+        @include m.text-style('md', 700);
+      }
     }
   }
 
@@ -230,8 +265,12 @@
     gap: 12px;
 
     h4 {
-      @include m.text-style('md', 600);
+      @include m.text-style('sm', 600);
       color: var(--text-secondary);
+
+      @include m.mq(sm) {
+        @include m.text-style('md', 600);
+      }
     }
 
     &__list {
@@ -266,13 +305,17 @@
         &__item {
           @include m.flex-box(flex-start, center);
           gap: 12px;
-          @include m.text-style('md', 600);
+          @include m.text-style('sm', 600);
           color: var(--text-secondary);
           padding: 14px 16px;
           background-color: var(--surface-2);
           border-radius: 12px;
           border: 2px solid color-mix(in srgb, var(--border) 60%, transparent);
           transition: all 0.2s ease;
+
+          @include m.mq(sm) {
+            @include m.text-style('md', 600);
+          }
 
           &:hover {
             box-shadow: var(--shadow);
@@ -282,21 +325,30 @@
             @include m.flex-box(center, center);
             min-width: 28px;
             height: 28px;
-            @include m.text-style('sm', 700);
+            @include m.text-style('xs', 700);
             background: linear-gradient(135deg, f.color(orange-700) 0%, f.color(orange-500) 100%);
             color: var(--text);
             border-radius: 8px;
             padding: 0 8px;
+
+            @include m.mq(sm) {
+              @include m.text-style('sm', 700);
+            }
           }
 
           &--empty {
-            @include m.text-style-extended('lg', 500, gray-700);
+            @include m.text-style-extended('md', 500, gray-700);
             color: var(--text-secondary);
             text-align: center;
             padding: 40px 20px;
             border: 2px dashed color-mix(in srgb, var(--border) 60%, transparent);
             border-radius: 12px;
             background: var(--surface-2);
+
+            @include m.mq(sm) {
+              @include m.text-style('lg', 500);
+              color: var(--text);
+            }
           }
         }
       }
@@ -328,8 +380,13 @@
     }
 
     span {
-      @include m.text-style-extended('sm', 600, gray-700);
+      @include m.text-style-extended('xs', 600, gray-700);
       color: var(--text-secondary);
+
+      @include m.mq(sm) {
+        @include m.text-style('sm', 600);
+        color: var(--text);
+      }
     }
   }
 }

--- a/src/features/Chat/Chat.module.scss
+++ b/src/features/Chat/Chat.module.scss
@@ -18,10 +18,15 @@
     border-bottom: 1px solid var(--border);
     display: inline-flex;
     @include m.flex-box(center, center);
-    padding: 20px 20px 16px 20px;
-    @include m.text-style('xl', 700);
+    padding: 10px 16px 8px 16px;
+    @include m.text-style('lg', 700);
     color: var(--text);
     flex-shrink: 0;
+
+    @include m.mq(sm) {
+      padding: 20px 20px 16px 20px;
+      @include m.text-style('xl', 700);
+    }
   }
 
   &__content {
@@ -185,12 +190,18 @@
 
   &__input {
     flex-shrink: 0;
-    padding: 16px 20px 20px 20px;
+    // 모바일에서 입력영역 패딩 축소
+    padding: 8px 12px 10px 12px;
     @include m.flex-box(center, center, row);
-    gap: 12px;
+    gap: 8px;
     background: var(--surface);
     backdrop-filter: blur(10px);
     border-top: 1px solid var(--border);
+
+    @include m.mq(sm) {
+      padding: 16px 20px 20px 20px;
+      gap: 12px;
+    }
 
     &__field {
       flex: 1;

--- a/src/features/Chat/Chat.module.scss
+++ b/src/features/Chat/Chat.module.scss
@@ -19,7 +19,9 @@
     display: inline-flex;
     @include m.flex-box(center, center);
     padding: 10px 16px 8px 16px;
+
     @include m.text-style('lg', 700);
+
     color: var(--text);
     flex-shrink: 0;
 
@@ -190,9 +192,9 @@
 
   &__input {
     flex-shrink: 0;
-    // 모바일에서 입력영역 패딩 축소
     padding: 8px 12px 10px 12px;
     @include m.flex-box(center, center, row);
+
     gap: 8px;
     background: var(--surface);
     backdrop-filter: blur(10px);

--- a/src/features/Mypage/AccountSetting/FaqModal/FaqModal.module.scss
+++ b/src/features/Mypage/AccountSetting/FaqModal/FaqModal.module.scss
@@ -8,8 +8,13 @@
 .faq-form {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  margin-top: 16px;
+  gap: 12px;
+  margin-top: 12px;
+
+  @include m.mq(sm) {
+    gap: 18px;
+    margin-top: 16px;
+  }
 
   &__label {
     @include m.flex-box(center, flex-start, column);

--- a/src/features/Mypage/AccountSetting/LogoutModal/LogoutModal.module.scss
+++ b/src/features/Mypage/AccountSetting/LogoutModal/LogoutModal.module.scss
@@ -2,7 +2,6 @@
 @use 'utils/functions' as f;
 
 .logout-modal {
-  min-width: 320px;
   max-width: 400px;
   width: 100%;
   border-radius: 20px;
@@ -10,11 +9,21 @@
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
 
+  @include m.mq(sm) {
+    min-width: 320px;
+  }
+
   &__actions {
-    margin-top: 32px;
-    padding-top: 20px;
+    margin-top: 20px;
+    padding-top: 14px;
     @include m.flex-box(space-between, center);
-    gap: 12px;
+    gap: 8px;
+
+    @include m.mq(sm) {
+      margin-top: 32px;
+      padding-top: 20px;
+      gap: 12px;
+    }
 
     button {
       flex: 1;

--- a/src/features/Mypage/FoodDotSelectionCard/FoodDotSelectionCard.module.scss
+++ b/src/features/Mypage/FoodDotSelectionCard/FoodDotSelectionCard.module.scss
@@ -18,10 +18,17 @@
   @include m.flex-box(flex-start, stretch, column);
 
   &__header {
-    @include m.flex-box(space-between, center);
+    @include m.flex-box(flex-start, flex-start, column);
     padding-bottom: 8px;
     border-bottom: 1px solid var(--border);
     margin-bottom: 16px;
+    gap: 4px;
+
+    @include m.mq(sm) {
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
   }
 
   &__title {
@@ -36,13 +43,12 @@
   }
 
   &__list {
-    margin: 0;
+    margin: 0 0 16px;
     padding: 0;
     list-style: none;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 12px;
-    margin-bottom: 16px;
   }
 
   &__item {
@@ -58,22 +64,34 @@
     cursor: pointer;
     border: 1px solid var(--border);
     border-radius: 10px;
-    transition: all 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      transform 0.2s ease,
+      border-color 0.2s ease;
 
     &:hover {
       background: var(--surface-hover);
       transform: translateY(-2px);
 
-      img {
-        transform: scale(1.15);
-        transition: transform 0.2s;
+      .food-dot-card__selected-img {
+        transform: scale(1.08);
       }
+    }
+
+    &-thumb {
+      width: 44px;
+      height: 44px;
+      @include m.flex-box(center, center);
+      overflow: hidden;
+      flex-shrink: 0;
     }
 
     &-img {
       width: 44px;
       height: 44px;
       object-fit: contain;
+      object-position: center bottom;
+      transition: transform 0.2s ease;
     }
   }
 
@@ -81,6 +99,7 @@
     @include m.text-style-extended(xs, 500, text-default);
     color: var(--text-secondary);
     text-align: center;
+    word-break: keep-all;
   }
 
   &__empty {
@@ -114,7 +133,9 @@
     @include m.text-style-extended(lg, 500, text-default);
     color: var(--text-secondary);
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition:
+      color 0.2s ease,
+      opacity 0.2s ease;
 
     &:hover {
       color: f.color(orange-700);
@@ -143,8 +164,13 @@
   &__list {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
-    gap: 10px;
+    gap: 8px;
     overflow: visible;
+
+    @include m.mq(sm) {
+      grid-template-columns: repeat(5, 1fr);
+      gap: 10px;
+    }
   }
 
   &__item {
@@ -154,13 +180,22 @@
   &__button {
     position: relative;
     @include m.flex-box(center, center);
-    width: 52px;
-    height: 52px;
+    width: 44px;
+    height: 44px;
     border: 1px solid var(--border);
     border-radius: 10px;
     background: var(--surface-2);
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      transform 0.2s ease,
+      border-color 0.2s ease,
+      box-shadow 0.2s ease;
+
+    @include m.mq(sm) {
+      width: 52px;
+      height: 52px;
+    }
 
     &:hover {
       background: var(--surface-hover);
@@ -172,11 +207,29 @@
       background: f.color(orange-100);
       box-shadow: 0 0 0 2px f.color(orange-200);
     }
+  }
 
-    img {
+  &__thumb {
+    width: 40px;
+    height: 40px;
+    @include m.flex-box(center, center);
+    overflow: hidden;
+
+    @include m.mq(sm) {
       width: 48px;
       height: 48px;
-      object-fit: contain;
+    }
+  }
+
+  &__img {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    object-position: center bottom;
+
+    @include m.mq(sm) {
+      width: 48px;
+      height: 48px;
     }
   }
 

--- a/src/features/Mypage/FoodDotSelectionCard/FoodDotSelectionCard.tsx
+++ b/src/features/Mypage/FoodDotSelectionCard/FoodDotSelectionCard.tsx
@@ -102,13 +102,15 @@ export default function FoodDotSelectionCard() {
             {selectedDots.map(dot => (
               <li key={dot.id} className={styles['food-dot-card__item']}>
                 <div className={styles['food-dot-card__selected']}>
-                  <Image
-                    src={dot.src}
-                    alt={dot.label}
-                    width={40}
-                    height={40}
-                    className={styles['food-dot-card__selected-img']}
-                  />
+                  <div className={styles['food-dot-card__selected-thumb']}>
+                    <Image
+                      src={dot.src}
+                      alt={dot.label}
+                      width={40}
+                      height={40}
+                      className={styles['food-dot-card__selected-img']}
+                    />
+                  </div>
                   <span className={styles['food-dot-card__label']}>{dot.label}</span>
                 </div>
               </li>
@@ -152,7 +154,16 @@ export default function FoodDotSelectionCard() {
                     onClick={() => handleToggleDot(dot.id)}
                     aria-pressed={isSelected}
                   >
-                    <Image src={dot.src} alt={dot.label} width={56} height={56} />
+                    <div className={styles['food-dot-modal__thumb']}>
+                      <Image
+                        src={dot.src}
+                        alt={dot.label}
+                        width={56}
+                        height={56}
+                        className={styles['food-dot-modal__img']}
+                      />
+                    </div>
+
                     {isSelected && (
                       <span className={styles['food-dot-modal__check']}>
                         <Check size={18} />

--- a/src/features/Mypage/MyPageHeader/MyPageHeader.module.scss
+++ b/src/features/Mypage/MyPageHeader/MyPageHeader.module.scss
@@ -111,6 +111,7 @@
   &__title {
     @include m.text-style(xl, 700);
     color: var(--text);
+
     word-break: keep-all;
     overflow-wrap: break-word;
   }
@@ -119,6 +120,7 @@
     margin-top: 4px;
     @include m.text-style(md, 400);
     color: var(--text-secondary);
+
     word-break: keep-all;
     overflow-wrap: break-word;
   }

--- a/src/features/Mypage/MyPageHeader/MyPageHeader.module.scss
+++ b/src/features/Mypage/MyPageHeader/MyPageHeader.module.scss
@@ -4,15 +4,24 @@
 
 .profile-header {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 30px;
-  padding: 18px 20px;
-  min-height: 200px;
+  gap: 16px;
+  padding: 20px 16px;
+  min-height: auto;
   background: var(--surface);
   border-radius: 24px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
   color: var(--text);
+
+  @include m.mq(sm) {
+    flex-direction: row;
+    align-items: center;
+    gap: 30px;
+    padding: 18px 20px;
+    min-height: 200px;
+  }
 
   svg {
     stroke: currentColor;
@@ -21,6 +30,11 @@
     position: relative;
     width: 100px;
     height: 100px;
+    align-self: center;
+
+    @include m.mq(sm) {
+      align-self: auto;
+    }
   }
 
   &__avatar-edit-button {
@@ -39,8 +53,10 @@
 
   &__avatar-menu {
     position: absolute;
-    right: -144px;
-    top: 82%;
+    left: 50%;
+    right: auto;
+    top: 100%;
+    transform: translateX(-50%);
     min-width: 160px;
     padding: 6px;
     background: var(--surface-2);
@@ -48,6 +64,13 @@
     border-radius: 10px;
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
     z-index: 20;
+
+    @include m.mq(sm) {
+      left: auto;
+      right: -144px;
+      top: 82%;
+      transform: none;
+    }
 
     button {
       display: flex;
@@ -76,33 +99,53 @@
   }
 
   &__body {
-    flex: 1;
+    width: 100%;
+    min-width: 0;
+
+    @include m.mq(sm) {
+      flex: 1;
+      width: auto;
+    }
   }
 
   &__title {
     @include m.text-style(xl, 700);
     color: var(--text);
+    word-break: keep-all;
+    overflow-wrap: break-word;
   }
 
   &__subtitle {
     margin-top: 4px;
     @include m.text-style(md, 400);
     color: var(--text-secondary);
+    word-break: keep-all;
+    overflow-wrap: break-word;
   }
 
   &__stats {
-    margin-top: 12px;
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-
-  &__food-dots {
-    margin-top: 12px;
+    margin-top: 8px;
     display: flex;
     gap: 6px;
     flex-wrap: wrap;
+
+    @include m.mq(sm) {
+      margin-top: 12px;
+      gap: 8px;
+    }
+  }
+
+  &__food-dots {
+    margin-top: 8px;
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
     align-items: center;
+
+    @include m.mq(sm) {
+      margin-top: 12px;
+      gap: 6px;
+    }
   }
 
   &__food-dot {

--- a/src/features/Room/RoomEntryCard/RoomEntryCard.module.scss
+++ b/src/features/Room/RoomEntryCard/RoomEntryCard.module.scss
@@ -24,7 +24,7 @@
     gap: 0;
 
     &__title {
-      @include m.text-style-extended('xl', 700, gray-900);
+      @include m.text-style-extended('lg', 700, gray-900);
       color: var(--text);
       margin-bottom: 6px;
       letter-spacing: -0.01em;
@@ -36,7 +36,7 @@
     }
 
     &__description {
-      @include m.text-style-extended('md', 400, gray-600);
+      @include m.text-style-extended('sm', 400, gray-600);
       color: var(--text);
       text-align: left;
       margin-bottom: 0;
@@ -64,7 +64,7 @@
     border: 1px solid var(--border);
     background: var(--surface-2);
     cursor: pointer;
-    @include m.text-style-extended('lg', 600, orange-800);
+    @include m.text-style-extended('md', 600, orange-800);
     color: var(--text-secondary);
     transition: all 0.18s cubic-bezier(0.4, 0, 0.2, 1);
 
@@ -86,7 +86,7 @@
     border-radius: 18px;
     background: var(--surface-2);
     text-align: center;
-    @include m.text-style-extended('lg', 600, orange-800);
+    @include m.text-style-extended('md', 600, orange-800);
     box-shadow: 0 1px 4px 0 rgba(239, 108, 0, 0.04);
 
     @include m.mq(sm) {
@@ -95,13 +95,13 @@
       margin-bottom: 36px;
     }
     &__main {
-      @include m.text-style-extended('lg', 600, text-default);
+      @include m.text-style-extended('md', 600, text-default);
       color: var(--text);
       margin-bottom: 6px;
     }
 
     &__sub {
-      @include m.text-style-extended('md', 600, text-default);
+      @include m.text-style-extended('sm', 600, text-default);
       color: var(--text-secondary);
       line-height: 1.6;
     }
@@ -113,7 +113,7 @@
     background: var(--surface-2);
     border-radius: 18px;
     text-align: center;
-    @include m.text-style-extended('md', 600, text-default);
+    @include m.text-style-extended('sm', 600, text-default);
     color: var(--text-secondary);
     box-shadow: 0 1px 4px 0 rgba(239, 108, 0, 0.04);
 

--- a/src/features/Roulette/Roulette.module.scss
+++ b/src/features/Roulette/Roulette.module.scss
@@ -9,19 +9,29 @@
   max-height: 870px;
 
   &__today {
-    @include m.text-style-extended('2xl', 600, gray-700);
+    @include m.text-style-extended('lg', 600, gray-700);
     color: var(--text);
     text-align: center;
 
+    @include m.mq(sm) {
+      @include m.text-style-extended('2xl', 600, gray-700);
+      color: var(--text);
+    }
+
     span {
-      @include m.text-style-extended('2xl', 800, orange-700);
+      @include m.text-style-extended('lg', 800, orange-700);
+
+      @include m.mq(sm) {
+        @include m.text-style-extended('2xl', 800, orange-700);
+      }
     }
   }
 
   &__wheel-wrapper {
     position: relative;
-    width: fit-content;
+    width: 100%;
     margin: 0 auto;
+    @include m.flex-box(center, center);
   }
 
   &__result-btn {
@@ -30,16 +40,23 @@
     @include m.flex-box(center, center);
 
     &__button {
-      width: 100px;
+      min-width: 80px;
+      padding: 8px 14px;
       background-color: f.color(white);
       border-radius: 24px;
       border: 1.5px solid f.color(orange-200);
+      white-space: nowrap;
+
       @include m.text-style-extended('xs', 700, orange-700);
-      padding: 8px;
+
+      @include m.mq(sm) {
+        min-width: 100px;
+        padding: 10px 18px;
+        @include m.text-style-extended('sm', 700, orange-700);
+      }
 
       @include m.mq(md) {
         @include m.text-style-extended('md', 700, orange-700);
-        padding: 8px;
       }
 
       &:hover:not(:disabled) {

--- a/src/features/Roulette/components/RouletteFilter/RouletteFilter.module.scss
+++ b/src/features/Roulette/components/RouletteFilter/RouletteFilter.module.scss
@@ -9,29 +9,44 @@
     padding: 4px;
     background: var(--surface);
     border-radius: 32px;
+
+    @include m.mq(sm) {
+      margin-top: 16px;
+      gap: 8px;
+      padding: 0 12px;
+    }
   }
 
   &__mode__tab {
-    width: 100px;
-    height: 36px;
     @include m.flex-box(center, center);
-    font-weight: 600;
+    width: 100px;
+    height: 30px;
+    padding: 0 8px;
     color: var(--text-secondary);
     background: transparent;
     border-radius: 32px;
     border: 1px solid var(--border);
     cursor: pointer;
     transition: all 0.2s ease;
+    white-space: nowrap;
+    @include m.text-style(xs, 600);
+
+    @include m.mq(sm) {
+      width: 100px;
+      height: 36px;
+      padding: 0 10px;
+    }
 
     @include m.mq(md) {
-      width: 200px;
+      width: 160px;
       height: 36px;
+      @include m.text-style(sm, 600);
     }
 
     @include m.mq(lg) {
       @include m.text-style(lg, 600);
-      width: 260px;
-      height: 48px;
+      width: 220px;
+      height: 44px;
     }
 
     &--active {
@@ -48,20 +63,32 @@
     gap: 8px;
     flex-wrap: wrap;
     width: 100%;
-    padding: 0 12px;
+
+    @include m.mq(sm) {
+      margin-top: 16px;
+      padding: 0 12px;
+    }
 
     @include m.mq(md) {
+      margin-top: 20px;
+      gap: 10px;
+    }
+
+    @include m.mq(lg) {
       gap: 12px;
     }
   }
 
   &__options__item {
     @include m.flex-box(center, center);
+    height: 22px;
     border-radius: 16px;
+    white-space: nowrap;
     @include m.text-style(xs, 400);
-    height: 32px;
-    padding: 0 12px;
-    box-sizing: border-box;
+    @include m.mq(sm) {
+      height: 32px;
+      padding: 0 12px;
+    }
 
     @include m.mq(md) {
       @include m.text-style(sm, 400);
@@ -78,6 +105,10 @@
 
   &__options__item__icon {
     @include m.flex-box(center, center);
-    margin-right: 6px;
+    margin-right: 2px;
+
+    @include m.mq(sm) {
+      margin-right: 6px;
+    }
   }
 }

--- a/src/features/Roulette/components/RouletteFilter/RouletteFilter.tsx
+++ b/src/features/Roulette/components/RouletteFilter/RouletteFilter.tsx
@@ -111,8 +111,7 @@ export default function RouletteFilter({
               disabled={disabled}
               variant="blue"
               mode={opt.isActive ? 'fill' : 'outline'}
-              padding="8px 18px"
-              fontSize="14px"
+              size="sm"
               className={styles['filter__options__item']}
               onClick={() => toggleFoodType(opt.value as Category)}
             >
@@ -128,8 +127,7 @@ export default function RouletteFilter({
               disabled={disabled}
               variant="blue"
               mode={opt.isActive ? 'fill' : 'outline'}
-              padding="8px 18px"
-              fontSize="14px"
+              size="sm"
               className={styles['filter__options__item']}
               onClick={() => toggleSituation(opt.value as Context)}
             >

--- a/src/features/Roulette/components/RouletteModal/RouletteModal.module.scss
+++ b/src/features/Roulette/components/RouletteModal/RouletteModal.module.scss
@@ -4,40 +4,76 @@
 // 모달 전체 블록
 .modal {
   &__content {
+    width: 100%;
+    max-width: 300px;
+    margin: 0 auto;
+    padding: 14px 14px 16px;
     background: var(--surface);
-    padding: 24px 24px 28px;
     border-radius: 16px;
-    width: 320px;
     text-align: center;
+
+    @include m.mq(sm) {
+      max-width: 320px;
+      padding: 24px 24px 28px;
+    }
   }
 
   &__description {
-    @include m.text-style('md', 500);
-    margin-bottom: 14px;
+    @include m.text-style(sm, 500);
+    margin-bottom: 10px;
     color: var(--text-secondary);
+
+    @include m.mq(sm) {
+      @include m.text-style(md, 500);
+      margin-bottom: 14px;
+    }
   }
 
   &__image {
+    display: block;
     width: 100%;
-    height: 240px;
+    height: 200px;
     object-fit: cover;
     border-radius: 14px;
     background: var(--surface-2);
+
+    @include m.mq(sm) {
+      height: 240px;
+    }
   }
 
   &__name {
-    @include m.text-style('2xl', 700);
+    @include m.text-style(lg, 700);
+    margin: 8px 0 12px;
     color: var(--text);
-    margin: 12px 0 22px;
+
+    @include m.mq(sm) {
+      @include m.text-style('2xl', 700);
+      margin: 12px 0 22px;
+    }
   }
 
   &__buttons {
     @include m.flex-box(center, center, column);
-    gap: 12px;
+    gap: 8px;
+    width: 100%;
+
+    @include m.mq(sm) {
+      gap: 12px;
+    }
 
     :global(button) {
       width: 100%;
+      min-height: 40px;
+      padding: 0 12px;
       border-radius: 12px;
+      font-size: 13px;
+
+      @include m.mq(sm) {
+        min-height: 48px;
+        padding: 0 16px;
+        font-size: 14px;
+      }
     }
 
     /* 닫기 버튼 */

--- a/src/features/WeatherMood/components/Weather/WeatherRecommend.module.scss
+++ b/src/features/WeatherMood/components/Weather/WeatherRecommend.module.scss
@@ -55,7 +55,6 @@
 
   &__content {
     flex: 1 1 240px;
-    min-width: 240px;
     display: grid;
     grid-template-columns: 1fr;
     row-gap: 4px;

--- a/src/shared/components/Carousel/Carousel.module.scss
+++ b/src/shared/components/Carousel/Carousel.module.scss
@@ -11,7 +11,6 @@
 
 .carousel {
   width: 100%;
-  min-width: 300px;
   overflow: hidden;
   border-radius: 16px;
   background: var(--surface);
@@ -80,8 +79,8 @@
 
   &__titleRow {
     width: 100%;
-    @include m.flex-box(space-between, center, row);
-    gap: 8px;
+    @include m.flex-box(flex-start, flex-start, column);
+    gap: 4px;
     min-width: 0;
 
     @include m.mq(sm) {
@@ -94,21 +93,17 @@
     font-size: 13px;
     font-weight: 700;
     color: var(--text);
-    white-space: nowrap;
     line-height: 1.3;
     letter-spacing: -0.01em;
-    flex: 1;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: block;
+    word-break: keep-all;
+    overflow-wrap: break-word;
 
     @include m.mq(sm) {
       @include m.text-style('xl', 700);
       line-height: 1.4;
       white-space: pre-line;
-      overflow: visible;
-      text-overflow: clip;
+      flex: 1;
     }
   }
 
@@ -126,13 +121,14 @@
 
   &__images {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: 8px;
     width: 100%;
     margin-top: 4px;
     min-width: 0;
 
     @include m.mq(sm) {
+      grid-template-columns: repeat(4, 1fr);
       gap: 16px;
       margin-top: 8px;
     }

--- a/src/shared/components/KakaoMap/KakaoMap.module.scss
+++ b/src/shared/components/KakaoMap/KakaoMap.module.scss
@@ -24,7 +24,7 @@
   flex: 1;
   width: 100%;
   height: 100%;
-  min-height: 800px;
+  min-height: 260px;
   overflow: hidden;
   border-radius: 24px;
   border: 1.5px solid f.color(gray-100);
@@ -32,6 +32,14 @@
   transition:
     box-shadow 0.2s,
     border-color 0.2s;
+
+  @include m.mq(sm) {
+    min-height: 320px;
+  }
+
+  @include m.mq(lg) {
+    min-height: 420px;
+  }
 
   &__place-list {
     width: 100%;

--- a/src/shared/components/Modal/Modal.module.scss
+++ b/src/shared/components/Modal/Modal.module.scss
@@ -17,10 +17,14 @@
   align-items: center;
   justify-content: center;
   background-color: rgba(0, 0, 0, 0.18);
-  padding: 0;
+  padding: 12px;
   position: fixed;
   inset: 0;
   z-index: 999;
+
+  @include m.mq(sm) {
+    padding: 0;
+  }
 }
 
 .modal {
@@ -32,26 +36,45 @@
   animation: fade-in 0.22s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
-  min-width: 320px;
+  min-width: 0;
+  width: 100%;
+  max-width: 340px;
+  box-sizing: border-box;
+
+  @include m.mq(sm) {
+    width: auto;
+    max-width: none;
+    min-width: 320px;
+  }
+
   @include m.mq(md) {
     min-width: 380px;
   }
 
   &__top {
     @include m.flex-box(flex-end, center);
-    padding: 16px 16px 0 16px;
+    padding: 12px 12px 0 12px;
     width: 100%;
+    box-sizing: border-box;
+
+    @include m.mq(sm) {
+      padding: 16px 16px 0 16px;
+    }
   }
 
   &__header {
     &__title {
-      margin: 12px 10px 6px 10px;
-      @include m.text-style('xl', 700);
+      margin: 8px 10px 4px 10px;
+      @include m.text-style(lg, 700);
       color: var(--text);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      word-break: keep-all;
+      overflow-wrap: break-word;
       letter-spacing: -0.02em;
+
+      @include m.mq(sm) {
+        margin: 12px 10px 6px 10px;
+        @include m.text-style(xl, 700);
+      }
 
       @include m.mq(md) {
         @include m.text-style('2xl', 700);
@@ -60,11 +83,19 @@
 
     &__close {
       @include m.flex-box(center, center);
+      width: 32px;
+      height: 32px;
       border-radius: 50%;
       background: var(--surface-2);
       border: 1px solid var(--border);
       color: var(--text-secondary);
       transition: all 0.2s ease;
+      flex-shrink: 0;
+
+      @include m.mq(sm) {
+        width: 36px;
+        height: 36px;
+      }
 
       &:hover {
         background: var(--surface-hover);
@@ -78,28 +109,42 @@
   }
 
   &__description {
-    margin: 8px 10px;
+    margin: 6px 10px 16px;
     text-align: center;
-    @include m.text-style('sm', 400);
+    @include m.text-style(xs, 400);
     color: var(--text-secondary);
-    line-height: 20px;
+    line-height: 18px;
     overflow: hidden;
     display: -webkit-box;
     line-clamp: 3;
     -webkit-box-orient: vertical;
-    margin-bottom: 24px;
+
+    @include m.mq(sm) {
+      margin: 8px 10px 24px;
+      @include m.text-style(sm, 400);
+      line-height: 20px;
+    }
+
     @include m.mq(md) {
-      @include m.text-style('md', 400);
+      @include m.text-style(md, 400);
     }
   }
 
   &__content {
     overflow: auto;
     height: 100%;
-    max-height: 90vh;
-    padding: 0 24px 24px 24px;
+    max-height: 80vh;
+    padding: 0 12px 16px 12px;
     background: var(--surface);
     border-bottom-left-radius: 24px;
     border-bottom-right-radius: 24px;
+    box-sizing: border-box;
+
+    @include m.mq(sm) {
+      max-height: 90vh;
+      padding: 0 24px 24px 24px;
+      border-bottom-left-radius: 24px;
+      border-bottom-right-radius: 24px;
+    }
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 모바일 / 태블릿 / 데스크톱 구간별 레이아웃 및 간격 재조정
- 페이지별 카드 높이, 여백, 정렬, 줄바꿈, overflow 동작 개선
- 룸 페이지의 콘텐츠 영역 높이 구조와 카드 최소 높이 재조정
- 모달 내부 간격, 버튼 크기, 텍스트 줄바꿈, 콘텐츠 영역 반응형 보완
- 뱃지 선택, 룰렛, 지도, 채팅 등 주요 UI의 화면 크기별 표시 안정성 개선
## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
### 메인 캐러셀 모바일
<img width="316" height="513" alt="모바일 홈" src="https://github.com/user-attachments/assets/f9726093-c605-42c4-b4c2-72ee2b5ad66c" />

### 마이페이지 모바일
<img width="365" height="809" alt="마이페이지 모바일" src="https://github.com/user-attachments/assets/00d0896e-a4b5-4755-94c3-be815fa5d423" />

### 같이정하기 모바일
<img width="363" height="699" alt="같이정하기 모바일" src="https://github.com/user-attachments/assets/f0b47c71-ce50-478b-8212-6b26bcbc77ac" />

### 채팅 모바일
<img width="366" height="804" alt="채팅" src="https://github.com/user-attachments/assets/541b4f3c-299c-4273-91bd-eaeb42045c74" />

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#167 
## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
- 페이지별로 분산되어 있던 높이, 간격, 정렬 기준을 화면 크기에 맞게 재조정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 전반적인 반응형 레이아웃 재정비(여러 컴포넌트의 브레이크포인트별 패딩·간격·정렬 조정)
  * 모바일 우선 타이포그래피 조정(기본 폰트 축소 및 스몰 스크린에서 복원)
  * 카드·모달·맵·캐러셀 등 컴포넌트의 크기·최대 높이 개선
  * 이미지 썸네일·버튼·리스트 등의 간격·전환·워드 래핑 미세 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->